### PR TITLE
feat: call signaling user layer — bot.call, Call object, double-tier events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.146",
+  "version": "1.0.147",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {
@@ -132,7 +132,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.137",
+    "@juzi/wechaty-puppet": "^1.0.138",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.44",
     "@swc/helpers": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "homepage": "https://github.com/wechaty/",
   "dependencies": {
-    "@juzi/wechaty-puppet-service": "1.0.114",
+    "@juzi/wechaty-puppet-service": "^1.0.115",
     "clone-class": "^1.1.1",
     "cmd-ts": "^0.10.0",
     "cockatiel": "^2.0.2",

--- a/src/mods/impls.ts
+++ b/src/mods/impls.ts
@@ -31,6 +31,7 @@
  */
 
 export {
+  CallImpl,
   ContactImpl,
   ContactSelfImpl,
   FavoriteImpl,
@@ -80,6 +81,7 @@ export {
 // }                                         from '../user-modules/mod.js'
 
 export type {
+  CallInterface,
   ContactInterface,
   ContactSelfInterface,
   DelayInterface,

--- a/src/mods/users.ts
+++ b/src/mods/users.ts
@@ -54,3 +54,8 @@ export type {
   WxxdProductInterface                   as WxxdProduct,
   WxxdOrderInterface                     as WxxdOrder,
 }                                               from '../user-modules/mod.js'
+
+export type {
+  CallStatus,
+  CallDirection,
+}                                               from '../user-modules/mod.js'

--- a/src/mods/users.ts
+++ b/src/mods/users.ts
@@ -25,6 +25,7 @@
  */
 
 export type {
+  CallInterface                          as Call,
   ContactInterface                       as Contact,
   ContactSelfInterface                   as ContactSelf,
   DelayInterface                         as Delay,

--- a/src/schemas/call-events.ts
+++ b/src/schemas/call-events.ts
@@ -1,31 +1,34 @@
-import { EventEmitter }  from 'events'
+import { EventEmitter }       from 'events'
 import type TypedEventEmitter from 'typed-emitter'
 
+import type { ContactInterface } from '../user-modules/contact.js'
+
 type CallEventListenerRinging = () => void | Promise<void>
-type CallEventListenerAccept  = () => void | Promise<void>
-type CallEventListenerReject  = (reason?: string) => void | Promise<void>
-type CallEventListenerHangup  = (reason?: string) => void | Promise<void>
-type CallEventListenerError   = (error: Error) => void | Promise<void>
+type CallEventListenerAccept  = (actor: ContactInterface) => void | Promise<void>
+type CallEventListenerReject  = (actor: ContactInterface, reason?: string) => void | Promise<void>
+type CallEventListenerCancel  = (reason?: string) => void | Promise<void>
+type CallEventListenerHangup  = (actor: ContactInterface, reason?: string) => void | Promise<void>
+type CallEventListenerEnded   = () => void | Promise<void>
 
 interface CallEventListeners {
   ringing : CallEventListenerRinging
   accept  : CallEventListenerAccept
   reject  : CallEventListenerReject
+  cancel  : CallEventListenerCancel
   hangup  : CallEventListenerHangup
-  error   : CallEventListenerError
+  ended   : CallEventListenerEnded
 }
 
-const CallEventEmitter = EventEmitter as any as new () => TypedEventEmitter<
-  CallEventListeners
->
+const CallEventEmitter = EventEmitter as any as new () => TypedEventEmitter<CallEventListeners>
 
 export type {
   CallEventListeners,
   CallEventListenerRinging,
   CallEventListenerAccept,
   CallEventListenerReject,
+  CallEventListenerCancel,
   CallEventListenerHangup,
-  CallEventListenerError,
+  CallEventListenerEnded,
 }
 export {
   CallEventEmitter,

--- a/src/schemas/call-events.ts
+++ b/src/schemas/call-events.ts
@@ -1,0 +1,32 @@
+import { EventEmitter }  from 'events'
+import type TypedEventEmitter from 'typed-emitter'
+
+type CallEventListenerRinging = () => void | Promise<void>
+type CallEventListenerAccept  = () => void | Promise<void>
+type CallEventListenerReject  = (reason?: string) => void | Promise<void>
+type CallEventListenerHangup  = (reason?: string) => void | Promise<void>
+type CallEventListenerError   = (error: Error) => void | Promise<void>
+
+interface CallEventListeners {
+  ringing : CallEventListenerRinging
+  accept  : CallEventListenerAccept
+  reject  : CallEventListenerReject
+  hangup  : CallEventListenerHangup
+  error   : CallEventListenerError
+}
+
+const CallEventEmitter = EventEmitter as any as new () => TypedEventEmitter<
+  CallEventListeners
+>
+
+export type {
+  CallEventListeners,
+  CallEventListenerRinging,
+  CallEventListenerAccept,
+  CallEventListenerReject,
+  CallEventListenerHangup,
+  CallEventListenerError,
+}
+export {
+  CallEventEmitter,
+}

--- a/src/schemas/mod.ts
+++ b/src/schemas/mod.ts
@@ -1,4 +1,8 @@
 import {
+  CallEventEmitter,
+  CallEventListeners,
+}                           from './call-events.js'
+import {
   ContactEventEmitter,
   ContactEventListeners,
 }                           from './contact-events.js'
@@ -17,12 +21,14 @@ import type {
 
 export type {
   Accepter,
+  CallEventListeners,
   ContactEventListeners,
   RoomEventListeners,
   WechatyEventListeners,
   WechatyEventName,
 }
 export {
+  CallEventEmitter,
   ContactEventEmitter,
   RoomEventEmitter,
   WechatyEventEmitter,

--- a/src/schemas/wechaty-events.ts
+++ b/src/schemas/wechaty-events.ts
@@ -26,6 +26,12 @@ const WECHATY_EVENT_DICT = {
   ready                : 'All underlined data source are ready for use.',
   start                : 'Will be emitted after the Wechaty had been started.',
   stop                 : 'Will be emitted after the Wechaty had been stopped.',
+  'call-ringing'       : 'Emit when an outgoing call is ringing on the peer side.',
+  'call-accept'        : 'Emit when a participant accepts the call.',
+  'call-reject'        : 'Emit when a participant rejects the call.',
+  'call-cancel'        : 'Emit when the caller cancels an outgoing call before it connects.',
+  'call-hangup'        : 'Emit when a participant hangs up a connected call.',
+  'call-ended'         : 'Emit when the call session is determined to be ended.',
 } as const
 
 type WechatyEventName  = keyof typeof WECHATY_EVENT_DICT
@@ -65,6 +71,12 @@ type WechatyEventListenerWxxdShop         = (payload: PUPPET.payloads.WxxdShop) 
 type WechatyEventListenerWxxdProduct      = (payload: PUPPET.payloads.WxxdProduct) => void | Promise<void>
 type WechatyEventListenerWxxdOrder        = (payload: PUPPET.payloads.WxxdOrder) => void | Promise<void>
 type WechatyEventListenerCall             = (call: CallInterface) => void | Promise<void>
+type WechatyEventListenerCallRinging      = (call: CallInterface) => void | Promise<void>
+type WechatyEventListenerCallAccept       = (call: CallInterface, actor: ContactInterface) => void | Promise<void>
+type WechatyEventListenerCallReject       = (call: CallInterface, actor: ContactInterface, reason?: string) => void | Promise<void>
+type WechatyEventListenerCallCancel       = (call: CallInterface, reason?: string) => void | Promise<void>
+type WechatyEventListenerCallHangup       = (call: CallInterface, actor: ContactInterface, reason?: string) => void | Promise<void>
+type WechatyEventListenerCallEnded        = (call: CallInterface) => void | Promise<void>
 
 /**
  * @desc       Wechaty Class Event Type
@@ -254,6 +266,12 @@ interface WechatyEventListeners {
   'wxxd-product'        : WechatyEventListenerWxxdProduct
   'wxxd-order'          : WechatyEventListenerWxxdOrder
   call                  : WechatyEventListenerCall
+  'call-ringing'        : WechatyEventListenerCallRinging
+  'call-accept'         : WechatyEventListenerCallAccept
+  'call-reject'         : WechatyEventListenerCallReject
+  'call-cancel'         : WechatyEventListenerCallCancel
+  'call-hangup'         : WechatyEventListenerCallHangup
+  'call-ended'          : WechatyEventListenerCallEnded
 }
 
 const WechatyEventEmitter = EventEmitter as any as new () => TypedEventEmitter<
@@ -296,6 +314,12 @@ export type {
   WechatyEventListenerWxxdProduct,
   WechatyEventListenerWxxdOrder,
   WechatyEventListenerCall,
+  WechatyEventListenerCallRinging,
+  WechatyEventListenerCallAccept,
+  WechatyEventListenerCallReject,
+  WechatyEventListenerCallCancel,
+  WechatyEventListenerCallHangup,
+  WechatyEventListenerCallEnded,
 }
 export {
   WechatyEventEmitter,

--- a/src/schemas/wechaty-events.ts
+++ b/src/schemas/wechaty-events.ts
@@ -14,6 +14,7 @@ import type {
   PostInterface,
   TagInterface,
   TagGroupInterface,
+  CallInterface,
 }                       from '../user-modules/mod.js'
 
 const WECHATY_EVENT_DICT = {
@@ -63,6 +64,7 @@ type WechatyEventListenerContactLeadFilled = (contact: ContactInterface, leads: 
 type WechatyEventListenerWxxdShop         = (payload: PUPPET.payloads.WxxdShop) => void | Promise<void>
 type WechatyEventListenerWxxdProduct      = (payload: PUPPET.payloads.WxxdProduct) => void | Promise<void>
 type WechatyEventListenerWxxdOrder        = (payload: PUPPET.payloads.WxxdOrder) => void | Promise<void>
+type WechatyEventListenerCall             = (call: CallInterface) => void | Promise<void>
 
 /**
  * @desc       Wechaty Class Event Type
@@ -251,6 +253,7 @@ interface WechatyEventListeners {
   'wxxd-shop'           : WechatyEventListenerWxxdShop
   'wxxd-product'        : WechatyEventListenerWxxdProduct
   'wxxd-order'          : WechatyEventListenerWxxdOrder
+  call                  : WechatyEventListenerCall
 }
 
 const WechatyEventEmitter = EventEmitter as any as new () => TypedEventEmitter<
@@ -292,6 +295,7 @@ export type {
   WechatyEventListenerWxxdShop,
   WechatyEventListenerWxxdProduct,
   WechatyEventListenerWxxdOrder,
+  WechatyEventListenerCall,
 }
 export {
   WechatyEventEmitter,

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -290,3 +290,115 @@ test('call.hangup() on connected call sends Hangup and transitions to ended', as
 
   await wechaty.stop()
 })
+
+// ---------------------------------------------------------------------------
+// 7. termination methods fail → local status is still ended (H1)
+// ---------------------------------------------------------------------------
+
+test('call.hangup() rejects when callControl fails but status transitions to ended', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const callControlStub = sandbox.stub(puppet, 'callControl' as any)
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer-hangup-fail')
+  // First call is the Invite – let it succeed.
+  callControlStub.onFirstCall().resolves(undefined)
+  const call = await contact.call()
+
+  // Simulate acceptance so hangup() is valid.
+  ;(puppet as any).emit('call', {
+    callId    : call.id,
+    signal    : PUPPET.types.CallSignal.Accept,
+    contactId : 'peer-hangup-fail',
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+  t.equal(call.status(), 'connected', 'prerequisite: status should be connected')
+
+  // Second call is the Hangup signal – make it fail.
+  callControlStub.onSecondCall().rejects(new Error('network error'))
+
+  await t.rejects(
+    call.hangup(),
+    /network error/,
+    'hangup() should re-throw the callControl error',
+  )
+
+  // Despite the network failure the local state must be ended.
+  t.equal(call.status(), 'ended', 'status should be ended even after callControl failure')
+
+  // A subsequent signal for the same callId should emit a bot-level error
+  // (pool has been cleaned up by the onEnded callback).
+  let errorEmitted = false
+  wechaty.on('error', () => { errorEmitted = true })
+
+  ;(puppet as any).emit('call', {
+    callId    : call.id,
+    signal    : PUPPET.types.CallSignal.Hangup,
+    contactId : 'peer-hangup-fail',
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.ok(errorEmitted, 'bot should emit error for unknown callId after pool cleanup')
+
+  await wechaty.stop()
+})
+
+// ---------------------------------------------------------------------------
+// 8. stop() drains the call pool (C1.1)
+// ---------------------------------------------------------------------------
+
+test('wechaty.stop() clears the call pool', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer-stop-test')
+  // Place an outgoing call that is never answered.
+  await contact.call()
+
+  // Pool must be non-empty before stop.
+  t.ok((wechaty as any).__callPool.size > 0, 'pool should be non-empty before stop()')
+
+  await wechaty.stop()
+
+  t.equal((wechaty as any).__callPool.size, 0, 'pool should be empty after stop()')
+})
+
+// ---------------------------------------------------------------------------
+// 9. TTL reclaims unanswered calls (C1.2)
+// ---------------------------------------------------------------------------
+
+test('Call TTL force-ends an unanswered outgoing call and emits error', async t => {
+  // Use fake timers scoped only to setTimeout to avoid disrupting wechaty's
+  // internal scheduling (setInterval, process timers, etc.).
+  const clock = sinon.useFakeTimers({ toFake: [ 'setTimeout' ] })
+
+  try {
+    const { puppet, wechaty } = buildWechaty()
+    await startAndLogin(puppet, wechaty, 'bot-ttl-test')
+
+    sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+    const contact = (wechaty.Contact as typeof ContactImpl).load('peer-ttl-test')
+    const call    = await contact.call()
+
+    t.equal(call.status(), 'calling', 'prerequisite: status should be calling')
+
+    let errorEmitted = false
+    call.on('error', () => { errorEmitted = true })
+
+    // Advance past the 60-second ringing TTL.
+    clock.tick(60_001)
+    // Allow any microtask / setImmediate callbacks to flush.
+    await new Promise(resolve => setImmediate(resolve))
+
+    t.ok(errorEmitted, 'call should emit error when TTL expires')
+    t.equal(call.status(), 'ended', 'status should be ended after TTL expiry')
+
+    await wechaty.stop()
+  } finally {
+    clock.restore()
+  }
+})

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S node --no-warnings --loader ts-node/esm
 /**
- * Tests for the Call first-class object and its lifecycle state machine.
+ * Tests for the Call first-class object and its lifecycle state machine
+ * against the @juzi/wechaty-puppet@^1.0.138 contract.
  */
 
 import {
@@ -12,16 +13,29 @@ import * as PUPPET    from '@juzi/wechaty-puppet'
 import { PuppetMock } from '@juzi/wechaty-puppet-mock'
 import { WechatyBuilder } from '../wechaty-builder.js'
 import type { CallInterface } from './call.js'
-import type { ContactImpl } from './contact.js'
+import type { ContactImpl, ContactInterface } from './contact.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+const sandbox = sinon.createSandbox()
+
 function buildWechaty () {
   const puppet  = new PuppetMock() as any
   const wechaty = WechatyBuilder.build({ puppet })
   return { puppet, wechaty }
+}
+
+function stubCallPayload (puppet: any, factory: (callId: string) => PUPPET.payloads.Call) {
+  const stub = sandbox.stub().callsFake(async (callId: string) => {
+    await new Promise(setImmediate)
+    return factory(callId)
+  })
+  puppet.callPayload = stub
+  // Used by Call.sync()
+  puppet.callPayloadDirty = sandbox.stub().resolves(undefined)
+  return stub
 }
 
 async function startAndLogin (puppet: any, wechaty: any, userId = 'bot-self') {
@@ -37,466 +51,879 @@ async function startAndLogin (puppet: any, wechaty: any, userId = 'bot-self') {
   await puppet.login(userId)
 }
 
-const sandbox = sinon.createSandbox()
+function flush (ticks = 8): Promise<void> {
+  let p = Promise.resolve()
+  for (let i = 0; i < ticks; i++) {
+    p = p.then(() => new Promise(resolve => setImmediate(resolve)))
+  }
+  return p
+}
 
 // ---------------------------------------------------------------------------
-// 1. contact.call() → returns Call with correct initial state
+// 1. bot.call() — outgoing, mints callId via puppet.callInvite, hydrates payload
 // ---------------------------------------------------------------------------
 
-test('contact.call() returns an outgoing Call with status=calling and media=audio', async t => {
+test('bot.call() returns an outgoing Call with status=calling, hydrated payload', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const callControlStub = sandbox.stub().resolves(undefined)
+  const CALL_ID   = 'call-id-minted-by-protocol'
+  const PEER_A_ID = 'peer-a'
+  const PEER_B_ID = 'peer-b'
+  const START_TS  = 1_700_000_000_000
 
-  ;(puppet as any).callControl = callControlStub
+  const callInviteStub = sandbox.stub().resolves(CALL_ID)
+  puppet.callInvite = callInviteStub
 
-  const PEER_ID = 'peer-contact-id'
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ PEER_A_ID, PEER_B_ID ],
+    media        : PUPPET.types.CallMediaType.Video,
+    startTime    : START_TS,
+  }))
+
+  const contactA = (wechaty.Contact as typeof ContactImpl).load(PEER_A_ID)
+  const contactB = (wechaty.Contact as typeof ContactImpl).load(PEER_B_ID)
+
+  const call: CallInterface = await (wechaty as any).call(
+    [ contactA, contactB ],
+    { media: PUPPET.types.CallMediaType.Video },
+  )
+
+  t.equal(call.id, CALL_ID, 'call.id should match callInvite return')
+  t.equal(call.direction(), 'outgoing', 'direction should be outgoing')
+  t.equal(call.status(), 'calling', 'status should be calling')
+  t.equal(call.media(), PUPPET.types.CallMediaType.Video, 'media should reflect payload')
+  t.same(call.startTime(), new Date(START_TS), 'startTime should match payload')
+  t.equal(call.endTime(), undefined, 'endTime should be undefined for a live call')
+
+  const participants = await call.participants()
+  t.same(participants.map(c => c.id).sort(), [ PEER_A_ID, PEER_B_ID ].sort(), 'participants should match payload')
+
+  t.ok(callInviteStub.calledOnce, 'puppet.callInvite should be called once')
+  t.same(
+    callInviteStub.firstCall.args,
+    [ [ PEER_A_ID, PEER_B_ID ], PUPPET.types.CallMediaType.Video ],
+    'callInvite args should be (contactIds, media)',
+  )
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('bot.call() rejects when contacts list is empty', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  await t.rejects(
+    (wechaty as any).call([]),
+    /at least one contact/,
+    'empty contacts should reject',
+  )
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+// ---------------------------------------------------------------------------
+// 2. contact.call() — 1v1 syntactic sugar over bot.call()
+// ---------------------------------------------------------------------------
+
+test('contact.call() delegates to bot.call([this])', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-sugar'
+  const PEER_ID = 'peer-sugar'
+
+  const callInviteStub = sandbox.stub().resolves(CALL_ID)
+  puppet.callInvite = callInviteStub
+
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ PEER_ID ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+
   const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
+  const call    = await contact.call()
 
-  const call: CallInterface = await contact.call()
-
-  t.equal(call.direction(), 'outgoing', 'should be outgoing')
-  t.equal(call.status(), 'calling', 'initial status should be calling')
+  t.equal(call.id, CALL_ID, 'call.id should match callInvite return')
   t.equal(call.media(), PUPPET.types.CallMediaType.Audio, 'default media should be audio')
-  t.ok(call.id, 'callId should be non-empty')
-
-  t.ok(callControlStub.calledOnce, 'puppet.callControl should have been called once')
-  const [ controlPayload ] = callControlStub.firstCall.args
-  t.equal(controlPayload.signal, PUPPET.types.CallSignal.Invite, 'should send Invite signal')
-  t.equal(controlPayload.peerId, PEER_ID, 'peerId should match contact id')
-  t.equal(controlPayload.media, PUPPET.types.CallMediaType.Audio, 'media should match')
+  t.same(
+    callInviteStub.firstCall.args,
+    [ [ PEER_ID ], PUPPET.types.CallMediaType.Audio ],
+    'callInvite args should be ([peerId], audio)',
+  )
 
   await wechaty.stop()
+  sandbox.restore()
 })
 
 // ---------------------------------------------------------------------------
-// 2. incoming call via puppet 'call' event with signal=Invite
+// 3. Incoming Invite — bot emits 'call' with a hydrated Call
 // ---------------------------------------------------------------------------
 
-test('incoming call: puppet emit call/Invite → bot emits call event, direction=incoming, status=ringing', async t => {
+test('incoming call: Invite hydrates payload then emits bot.on("call")', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const CALL_ID     = 'call-id-incoming'
-  const CALLER_ID   = 'caller-contact-id'
+  const CALL_ID   = 'call-id-incoming'
+  const CALLER_ID = 'caller-incoming'
+  const START_TS  = 1_700_000_000_999
 
-  let receivedCall: CallInterface | undefined
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : CALLER_ID,
+    participants : [ CALLER_ID, 'bot-self' ],
+    media        : PUPPET.types.CallMediaType.Video,
+    startTime    : START_TS,
+  }))
 
-  wechaty.on('call', (call: CallInterface) => {
-    receivedCall = call
-  })
+  let received: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { received = c })
 
   ;(puppet as any).emit('call', {
     callId    : CALL_ID,
     signal    : PUPPET.types.CallSignal.Invite,
     contactId : CALLER_ID,
-    media     : PUPPET.types.CallMediaType.Video,
+    timestamp : START_TS,
   } as PUPPET.payloads.EventCall)
+  await flush()
 
-  await new Promise(resolve => setImmediate(resolve))
+  t.ok(received, 'bot should emit call event for Invite')
+  t.equal(received!.id, CALL_ID, 'call.id should match')
+  t.equal(received!.direction(), 'incoming', 'direction should be incoming')
+  t.equal(received!.status(), 'ringing', 'status should be ringing')
+  t.equal(received!.media(), PUPPET.types.CallMediaType.Video, 'media should reflect payload')
 
-  t.ok(receivedCall, 'bot should emit call event')
-  t.equal(receivedCall!.id, CALL_ID, 'call.id should match')
-  t.equal(receivedCall!.direction(), 'incoming', 'should be incoming')
-  t.equal(receivedCall!.status(), 'ringing', 'initial status should be ringing')
-  t.equal(receivedCall!.contact().id, CALLER_ID, 'contact().id should match caller')
+  const starter = await received!.starter()
+  t.ok(starter, 'starter should be resolvable')
+  t.equal(starter!.id, CALLER_ID, 'starter should be the caller')
 
   await wechaty.stop()
+  sandbox.restore()
 })
 
-// ---------------------------------------------------------------------------
-// 3. outgoing call: ringing and accept signals cause status transitions + events
-// ---------------------------------------------------------------------------
-
-test('outgoing call: ringing signal → status=ringing + emit ringing; accept signal → status=connected + emit accept', async t => {
+test('duplicate Invite for the same callId is ignored', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
-
-  const PEER_ID = 'peer-id-outgoing'
-  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
-  const call: CallInterface = await contact.call()
-
-  const ringingEmitted = await new Promise<boolean>(resolve => {
-    call.on('ringing', () => resolve(true))
-    ;(puppet as any).emit('call', {
-      callId    : call.id,
-      signal    : PUPPET.types.CallSignal.Ringing,
-      contactId : PEER_ID,
-    } as PUPPET.payloads.EventCall)
-    setTimeout(() => resolve(false), 100)
-  })
-
-  t.ok(ringingEmitted, 'call should emit ringing')
-  t.equal(call.status(), 'ringing', 'status should be ringing after Ringing signal')
-
-  const acceptEmitted = await new Promise<boolean>(resolve => {
-    call.on('accept', () => resolve(true))
-    ;(puppet as any).emit('call', {
-      callId    : call.id,
-      signal    : PUPPET.types.CallSignal.Accept,
-      contactId : PEER_ID,
-    } as PUPPET.payloads.EventCall)
-    setTimeout(() => resolve(false), 100)
-  })
-
-  t.ok(acceptEmitted, 'call should emit accept')
-  t.equal(call.status(), 'connected', 'status should be connected after Accept signal')
-
-  await wechaty.stop()
-})
-
-// ---------------------------------------------------------------------------
-// 4. incoming call.accept() → callControl receives Accept + status=connected
-//    illegal call.accept() on outgoing → rejects
-// ---------------------------------------------------------------------------
-
-test('incoming call.accept() sends Accept signal and transitions to connected', async t => {
-  const { puppet, wechaty } = buildWechaty()
-  await startAndLogin(puppet, wechaty)
-
-  const callControlStub = sandbox.stub().resolves(undefined)
-
-  ;(puppet as any).callControl = callControlStub
-
-  const CALL_ID   = 'call-id-accept-test'
-  const CALLER_ID = 'caller-id'
-
-  let incomingCall: CallInterface | undefined
-  wechaty.on('call', (c: CallInterface) => { incomingCall = c })
-
-  ;(puppet as any).emit('call', {
-    callId    : CALL_ID,
-    signal    : PUPPET.types.CallSignal.Invite,
-    contactId : CALLER_ID,
-  } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
-
-  t.ok(incomingCall, 'should have received an incoming call')
-  await incomingCall!.accept()
-
-  t.equal(incomingCall!.status(), 'connected', 'status should be connected after accept()')
-  const acceptCall = callControlStub.getCalls().find(c => c.args[0]?.signal === PUPPET.types.CallSignal.Accept)
-  t.ok(acceptCall, 'callControl should have been called with Accept')
-
-  await wechaty.stop()
-})
-
-// ---------------------------------------------------------------------------
-// 4b. duplicate Invite for same callId is silently dropped (M1 guard)
-// ---------------------------------------------------------------------------
-
-test('duplicate Invite for same callId is ignored: call event fires once, original call survives', async t => {
-  const { puppet, wechaty } = buildWechaty()
-  await startAndLogin(puppet, wechaty)
-
-  const CALL_ID   = 'call-id-dup-invite'
+  const CALL_ID   = 'call-id-dup'
   const CALLER_ID = 'caller-dup'
 
-  let callEventCount = 0
-  let firstCall: CallInterface | undefined
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : CALLER_ID,
+    participants : [ CALLER_ID, 'bot-self' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
 
-  wechaty.on('call', (c: CallInterface) => {
-    callEventCount++
-    if (!firstCall) {
-      firstCall = c
+  let count = 0
+  wechaty.on('call', () => { count++ })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    timestamp : 1,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    timestamp : 2,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+
+  t.equal(count, 1, "'call' should fire once even on duplicate Invite")
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+// ---------------------------------------------------------------------------
+// 4. Ringing / Accept double-emit on outgoing
+// ---------------------------------------------------------------------------
+
+test('outgoing Ringing → object + bot emit; Accept → object + bot emit, status=connected', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-outgoing-ringing-accept'
+  const PEER_ID = 'peer-ringing-accept'
+
+  puppet.callInvite = sandbox.stub().resolves(CALL_ID)
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', PEER_ID ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
+  const call    = await contact.call()
+
+  let objectRinging = false
+  let botRinging    = false
+  call.on('ringing', () => { objectRinging = true })
+  wechaty.on('call-ringing', (c: CallInterface) => { if (c.id === CALL_ID) botRinging = true })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Ringing,
+    contactId : PEER_ID,
+    timestamp : 2,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+
+  t.ok(objectRinging, "object should emit 'ringing'")
+  t.ok(botRinging,    "bot should emit 'call-ringing'")
+  t.equal(call.status(), 'ringing', 'status should be ringing')
+
+  let objectActor: ContactInterface | undefined
+  let botActor:    ContactInterface | undefined
+  call.on('accept', actor => { objectActor = actor })
+  wechaty.on('call-accept', (c: CallInterface, actor: ContactInterface) => {
+    if (c.id === CALL_ID) {
+      botActor = actor
     }
   })
 
-  // First Invite — should create a call and emit 'call'
   ;(puppet as any).emit('call', {
     callId    : CALL_ID,
-    signal    : PUPPET.types.CallSignal.Invite,
-    contactId : CALLER_ID,
-    media     : PUPPET.types.CallMediaType.Audio,
+    signal    : PUPPET.types.CallSignal.Accept,
+    contactId : PEER_ID,
+    timestamp : 3,
   } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
+  await flush()
 
-  t.equal(callEventCount, 1, "'call' event should fire exactly once after first Invite")
-  t.ok(firstCall, 'first Call instance should be captured')
-  t.equal(firstCall!.status(), 'ringing', 'first call should be in ringing state')
-
-  // Second Invite with the same callId — guard should drop it silently
-  let errorEmitted = false
-  wechaty.on('error', () => { errorEmitted = true })
-
-  ;(puppet as any).emit('call', {
-    callId    : CALL_ID,
-    signal    : PUPPET.types.CallSignal.Invite,
-    contactId : CALLER_ID,
-    media     : PUPPET.types.CallMediaType.Audio,
-  } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
-
-  t.equal(callEventCount, 1, "'call' event must not fire again for duplicate Invite")
-  t.notOk(errorEmitted, 'no error event should be emitted for a duplicate Invite')
-
-  // The original call instance must still be alive and responsive to subsequent signals
-  const hangupEmitted = await new Promise<boolean>(resolve => {
-    firstCall!.on('hangup', () => resolve(true))
-    ;(puppet as any).emit('call', {
-      callId    : CALL_ID,
-      signal    : PUPPET.types.CallSignal.Cancel,
-      contactId : CALLER_ID,
-    } as PUPPET.payloads.EventCall)
-    setTimeout(() => resolve(false), 100)
-  })
-
-  t.ok(hangupEmitted, 'original Call instance should still handle subsequent signals after duplicate was dropped')
-  t.equal(firstCall!.status(), 'ended', 'original call should reach ended state after Cancel signal')
+  t.ok(objectActor, 'object accept actor should be set')
+  t.equal(objectActor!.id, PEER_ID, 'object accept actor should be the peer')
+  t.ok(botActor, 'bot accept actor should be set')
+  t.equal(botActor!.id, PEER_ID, 'bot accept actor should be the peer')
+  t.equal(call.status(), 'connected', 'status should be connected after Accept')
 
   await wechaty.stop()
+  sandbox.restore()
 })
 
-test('outgoing call.accept() throws an error (invalid direction)', async t => {
+// ---------------------------------------------------------------------------
+// 5. accept() control on incoming
+// ---------------------------------------------------------------------------
+
+test('incoming call.accept() invokes puppet.callAccept(callId) and connects', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
+  const CALL_ID   = 'call-id-accept'
+  const CALLER_ID = 'caller-accept'
 
-  const contact = (wechaty.Contact as typeof ContactImpl).load('some-peer')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : CALLER_ID,
+    participants : [ CALLER_ID, 'bot-self' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const acceptStub = sandbox.stub().resolves(undefined)
+  puppet.callAccept = acceptStub
+
+  let incoming: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { incoming = c })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    timestamp : 1,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+
+  t.ok(incoming, 'should receive incoming call')
+  await incoming!.accept()
+
+  t.equal(incoming!.status(), 'connected', 'status should be connected after accept()')
+  t.ok(acceptStub.calledOnce, 'puppet.callAccept should be called once')
+  t.same(acceptStub.firstCall.args, [ CALL_ID ], 'callAccept args should be [callId]')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('outgoing call.accept() throws (invalid direction)', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  puppet.callInvite = sandbox.stub().resolves('call-id-outgoing-accept-bad')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
   const call    = await contact.call()
 
-  await t.rejects(
-    call.accept(),
-    /invalid/i,
-    'accept() on outgoing call should throw',
-  )
+  await t.rejects(call.accept(), /invalid/i, 'accept() on outgoing should throw')
 
   await wechaty.stop()
+  sandbox.restore()
 })
 
 // ---------------------------------------------------------------------------
-// 5. peer Cancel → callee call emits 'hangup' + status=ended + pool cleanup
+// 6. reject() control on incoming + Reject signal terminal handling (outgoing 1v1)
 // ---------------------------------------------------------------------------
 
-test('outgoing Cancel signal received by callee → call emits hangup, status=ended, pool cleanup', async t => {
+test('incoming call.reject() invokes puppet.callReject(callId, reason) and ends', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const CALL_ID   = 'call-id-cancel-test'
+  const CALL_ID = 'call-id-reject'
+
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'caller-x',
+    participants : [ 'caller-x', 'bot-self' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const rejectStub = sandbox.stub().resolves(undefined)
+  puppet.callReject = rejectStub
+
+  let incoming: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { incoming = c })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : 'caller-x',
+    timestamp : 1,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+
+  await incoming!.reject('busy')
+  t.equal(incoming!.status(), 'ended', 'status should be ended after reject()')
+  t.same(rejectStub.firstCall.args, [ CALL_ID, 'busy' ], 'callReject args should be [callId, reason]')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('outgoing 1v1 Reject from peer → bot emits call-reject + call-ended, pool cleaned', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-outgoing-rejected'
+  const PEER_ID = 'peer-rejecter'
+
+  puppet.callInvite = sandbox.stub().resolves(CALL_ID)
+
+  // Initial payload: live; on second pull (sync after Reject) the call has endTime set.
+  let pulls = 0
+  puppet.callPayload = sandbox.stub().callsFake(async (id: string) => {
+    pulls++
+    await new Promise(setImmediate)
+    return {
+      id,
+      starter      : 'bot-self',
+      participants : [ 'bot-self', PEER_ID ],
+      media        : PUPPET.types.CallMediaType.Audio,
+      startTime    : 1,
+      endTime      : pulls === 1 ? undefined : 100,
+    } as PUPPET.payloads.Call
+  })
+  puppet.callPayloadDirty = sandbox.stub().resolves(undefined)
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
+  const call    = await contact.call()
+
+  let rejectActor: ContactInterface | undefined
+  let rejectReason: string | undefined
+  let endedEmitCount = 0
+  wechaty.on('call-reject', (c: CallInterface, actor: ContactInterface, reason?: string) => {
+    if (c.id === CALL_ID) {
+      rejectActor  = actor
+      rejectReason = reason
+    }
+  })
+  wechaty.on('call-ended', (c: CallInterface) => { if (c.id === CALL_ID) endedEmitCount++ })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Reject,
+    contactId : PEER_ID,
+    reason    : 'busy',
+    timestamp : 50,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+
+  t.ok(rejectActor, 'call-reject actor should be set')
+  t.equal(rejectActor!.id, PEER_ID, 'call-reject actor should be the peer')
+  t.equal(rejectReason, 'busy', 'call-reject reason should be passed through')
+  t.equal(endedEmitCount, 1, 'call-ended should fire exactly once after Reject terminates the 1v1 call')
+  t.equal(call.status(), 'ended', 'status should be ended after terminal Reject')
+  t.notOk((wechaty as any).__callPool.has(CALL_ID), 'call should be evicted from pool')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+// ---------------------------------------------------------------------------
+// 7. Cancel signal received by callee → cancel + ended emitted
+// ---------------------------------------------------------------------------
+
+test('Cancel signal terminates incoming call; emits cancel + ended; pool cleaned; status flips before cancel handler runs', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID   = 'call-id-cancel'
   const CALLER_ID = 'caller-cancel'
 
-  let incomingCall: CallInterface | undefined
-  wechaty.on('call', (c: CallInterface) => { incomingCall = c })
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : CALLER_ID,
+    participants : [ CALLER_ID, 'bot-self' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+
+  let incoming: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { incoming = c })
 
   ;(puppet as any).emit('call', {
     callId    : CALL_ID,
     signal    : PUPPET.types.CallSignal.Invite,
     contactId : CALLER_ID,
+    timestamp : 1,
   } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
+  await flush()
 
-  t.ok(incomingCall, 'should have received incoming call')
-
-  const hangupEmitted = await new Promise<boolean>(resolve => {
-    incomingCall!.on('hangup', () => resolve(true))
-    ;(puppet as any).emit('call', {
-      callId    : CALL_ID,
-      signal    : PUPPET.types.CallSignal.Cancel,
-      contactId : CALLER_ID,
-    } as PUPPET.payloads.EventCall)
-    setTimeout(() => resolve(false), 100)
+  let objectCancelReason: string | undefined
+  let botCancelReason: string | undefined
+  let statusInCancelHandler: string | undefined
+  let endedFiredCount = 0
+  incoming!.on('cancel', reason => {
+    objectCancelReason = reason
+    statusInCancelHandler = incoming!.status()
   })
-
-  t.ok(hangupEmitted, "Cancel from peer should emit 'hangup' on callee's call")
-  t.equal(incomingCall!.status(), 'ended', 'status should be ended')
-
-  // After ended, a subsequent signal for the same callId should emit an error
-  let errorEmitted = false
-  wechaty.on('error', () => { errorEmitted = true })
+  wechaty.on('call-cancel', (c: CallInterface, reason?: string) => {
+    if (c.id === CALL_ID) {
+      botCancelReason = reason
+    }
+  })
+  wechaty.on('call-ended', (c: CallInterface) => { if (c.id === CALL_ID) endedFiredCount++ })
 
   ;(puppet as any).emit('call', {
     callId    : CALL_ID,
-    signal    : PUPPET.types.CallSignal.Hangup,
+    signal    : PUPPET.types.CallSignal.Cancel,
     contactId : CALLER_ID,
+    reason    : 'caller-aborted',
+    timestamp : 2,
   } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
+  await flush()
 
-  t.ok(errorEmitted, 'bot should emit error for unknown callId after pool cleanup')
+  t.equal(objectCancelReason, 'caller-aborted', "object 'cancel' reason should match")
+  t.equal(botCancelReason, 'caller-aborted', "bot 'call-cancel' reason should match")
+  t.equal(endedFiredCount, 1, "'call-ended' should fire exactly once after Cancel (idempotent via __endedEmitted)")
+  t.equal(statusInCancelHandler, 'ended', "status should be 'ended' inside the cancel handler (no race window)")
+  t.equal(incoming!.status(), 'ended', 'status should be ended')
+  t.notOk((wechaty as any).__callPool.has(CALL_ID), 'call should be evicted from pool')
 
   await wechaty.stop()
+  sandbox.restore()
 })
 
 // ---------------------------------------------------------------------------
-// 6. call.hangup() on connected call
+// 8. hangup() control on connected
 // ---------------------------------------------------------------------------
 
-test('call.hangup() on connected call sends Hangup and transitions to ended', async t => {
+test('call.hangup() on connected call invokes puppet.callHangup and ends', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const callControlStub = sandbox.stub().resolves(undefined)
+  const CALL_ID = 'call-id-hangup'
+  const PEER_ID = 'peer-hangup'
 
-  ;(puppet as any).callControl = callControlStub
+  puppet.callInvite = sandbox.stub().resolves(CALL_ID)
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', PEER_ID ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const hangupStub = sandbox.stub().resolves(undefined)
+  puppet.callHangup = hangupStub
 
-  const contact = (wechaty.Contact as typeof ContactImpl).load('peer-hangup-test')
+  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
   const call    = await contact.call()
 
-  // Simulate peer accepting the call
   ;(puppet as any).emit('call', {
-    callId    : call.id,
+    callId    : CALL_ID,
     signal    : PUPPET.types.CallSignal.Accept,
-    contactId : 'peer-hangup-test',
+    contactId : PEER_ID,
+    timestamp : 2,
   } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
+  await flush()
 
-  t.equal(call.status(), 'connected', 'status should be connected')
+  t.equal(call.status(), 'connected', 'prerequisite: call should be connected')
 
-  await call.hangup()
-
+  await call.hangup('done')
   t.equal(call.status(), 'ended', 'status should be ended after hangup()')
-  const hangupCall = callControlStub.getCalls().find(c => c.args[0]?.signal === PUPPET.types.CallSignal.Hangup)
-  t.ok(hangupCall, 'callControl should have been called with Hangup signal')
+  t.same(hangupStub.firstCall.args, [ CALL_ID, 'done' ], 'callHangup args should be [callId, reason]')
 
   await wechaty.stop()
+  sandbox.restore()
 })
 
-// ---------------------------------------------------------------------------
-// 7. termination methods fail → local status is still ended (H1)
-// ---------------------------------------------------------------------------
-
-test('call.hangup() rejects when callControl fails but status transitions to ended', async t => {
+test('call.hangup() rejects when puppet.callHangup fails but local status still ends', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const callControlStub = sandbox.stub()
+  puppet.callInvite = sandbox.stub().resolves('call-id-hangup-fail')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const hangupStub = sandbox.stub().rejects(new Error('network error'))
+  puppet.callHangup = hangupStub
 
-  ;(puppet as any).callControl = callControlStub
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
 
-  const contact = (wechaty.Contact as typeof ContactImpl).load('peer-hangup-fail')
-  // First call is the Invite – let it succeed.
-  callControlStub.onFirstCall().resolves(undefined)
-  const call = await contact.call()
-
-  // Simulate acceptance so hangup() is valid.
   ;(puppet as any).emit('call', {
     callId    : call.id,
     signal    : PUPPET.types.CallSignal.Accept,
-    contactId : 'peer-hangup-fail',
+    contactId : 'peer',
+    timestamp : 2,
   } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
-  t.equal(call.status(), 'connected', 'prerequisite: status should be connected')
+  await flush()
+  t.equal(call.status(), 'connected', 'prerequisite: call should be connected')
 
-  // Second call is the Hangup signal – make it fail.
-  callControlStub.onSecondCall().rejects(new Error('network error'))
-
-  await t.rejects(
-    call.hangup(),
-    /network error/,
-    'hangup() should re-throw the callControl error',
-  )
-
-  // Despite the network failure the local state must be ended.
-  t.equal(call.status(), 'ended', 'status should be ended even after callControl failure')
-
-  // A subsequent signal for the same callId should emit a bot-level error
-  // (pool has been cleaned up by the onEnded callback).
-  let errorEmitted = false
-  wechaty.on('error', () => { errorEmitted = true })
-
-  ;(puppet as any).emit('call', {
-    callId    : call.id,
-    signal    : PUPPET.types.CallSignal.Hangup,
-    contactId : 'peer-hangup-fail',
-  } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
-
-  t.ok(errorEmitted, 'bot should emit error for unknown callId after pool cleanup')
+  await t.rejects(call.hangup(), /network error/, 'hangup() should re-throw')
+  t.equal(call.status(), 'ended', 'status should still be ended despite failure')
 
   await wechaty.stop()
+  sandbox.restore()
 })
 
 // ---------------------------------------------------------------------------
-// 8. stop() drains the call pool (C1.1)
+// 9. add() invokes puppet.callAdd(callId, contactIds)
+// ---------------------------------------------------------------------------
+
+test('call.add() invokes puppet.callAdd with the contact ids', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-add'
+
+  puppet.callInvite = sandbox.stub().resolves(CALL_ID)
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const addStub = sandbox.stub().resolves(undefined)
+  puppet.callAdd = addStub
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
+
+  const newContactA = (wechaty.Contact as typeof ContactImpl).load('newA')
+  const newContactB = (wechaty.Contact as typeof ContactImpl).load('newB')
+
+  await call.add([ newContactA, newContactB ])
+  t.same(addStub.firstCall.args, [ CALL_ID, [ 'newA', 'newB' ] ], 'callAdd args should be [callId, contactIds]')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+// ---------------------------------------------------------------------------
+// 10. mediaEndpoint() pass-through
+// ---------------------------------------------------------------------------
+
+test('call.mediaEndpoint() forwards to puppet.callMediaEndpoint', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-media'
+
+  puppet.callInvite = sandbox.stub().resolves(CALL_ID)
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const endpoint: PUPPET.payloads.CallMediaEndpoint = {
+    url   : 'wss://media.example/sfu',
+    token : 'token-xyz',
+  }
+  const endpointStub = sandbox.stub().resolves(endpoint)
+  puppet.callMediaEndpoint = endpointStub
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
+
+  const got = await call.mediaEndpoint()
+  t.same(got, endpoint, 'mediaEndpoint should pass through')
+  t.same(endpointStub.firstCall.args, [ CALL_ID ], 'callMediaEndpoint args should be [callId]')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+// ---------------------------------------------------------------------------
+// 11. wechaty.stop() drains the call pool
 // ---------------------------------------------------------------------------
 
 test('wechaty.stop() clears the call pool', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
+  puppet.callInvite = sandbox.stub().resolves('call-id-stop')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
 
-  const contact = (wechaty.Contact as typeof ContactImpl).load('peer-stop-test')
-  // Place an outgoing call that is never answered.
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
   await contact.call()
 
-  // Pool must be non-empty before stop.
   t.ok((wechaty as any).__callPool.size > 0, 'pool should be non-empty before stop()')
 
   await wechaty.stop()
-
   t.equal((wechaty as any).__callPool.size, 0, 'pool should be empty after stop()')
+
+  sandbox.restore()
 })
 
 // ---------------------------------------------------------------------------
-// 9. TTL reclaims unanswered calls (C1.2)
+// 12. Unknown callId signal is silently dropped (no error event)
 // ---------------------------------------------------------------------------
 
-test('Call TTL force-ends an unanswered outgoing call and emits error', async t => {
-  // Use fake timers scoped only to setTimeout to avoid disrupting wechaty's
-  // internal scheduling (setInterval, process timers, etc.).
-  const clock = sinon.useFakeTimers({ toFake: [ 'setTimeout' ] })
+test('signal for unknown callId is dropped, not surfaced as error', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
 
-  try {
-    const { puppet, wechaty } = buildWechaty()
-    await startAndLogin(puppet, wechaty, 'bot-ttl-test')
+  let errorEmitted = false
+  wechaty.on('error', () => { errorEmitted = true })
 
-    ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
+  ;(puppet as any).emit('call', {
+    callId    : 'never-seen',
+    signal    : PUPPET.types.CallSignal.Hangup,
+    contactId : 'someone',
+    timestamp : 1,
+  } as PUPPET.payloads.EventCall)
+  await flush()
 
-    const contact = (wechaty.Contact as typeof ContactImpl).load('peer-ttl-test')
-    const call    = await contact.call()
+  t.notOk(errorEmitted, 'unknown callId should not emit error')
 
-    t.equal(call.status(), 'calling', 'prerequisite: status should be calling')
-
-    let errorEmitted = false
-    call.on('error', () => { errorEmitted = true })
-
-    // Advance past the 60-second ringing TTL.
-    clock.tick(60_001)
-    // Allow any microtask / setImmediate callbacks to flush.
-    await new Promise(resolve => setImmediate(resolve))
-
-    t.ok(errorEmitted, 'call should emit error when TTL expires')
-    t.equal(call.status(), 'ended', 'status should be ended after TTL expiry')
-
-    await wechaty.stop()
-  } finally {
-    clock.restore()
-  }
+  await wechaty.stop()
+  sandbox.restore()
 })
 
 // ---------------------------------------------------------------------------
-// 8. TTL expiry must not crash the process when nobody listens for 'error'
-//    (Node throws synchronously on unhandled 'error' emit inside the timer
-//    callback, which would take down the whole bot process).
+// 13. Local control methods evict from pool + emit object 'ended'
 // ---------------------------------------------------------------------------
 
-test('Call TTL reaps an ignored call without error listeners and without throwing', async t => {
-  const clock = sinon.useFakeTimers({ toFake: [ 'setTimeout' ] })
+test("local reject() evicts from pool and emits object 'ended' + bot 'call-ended'", async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
 
-  try {
-    const { puppet, wechaty } = buildWechaty()
-    await startAndLogin(puppet, wechaty, 'bot-ttl-no-listener')
+  const CALL_ID   = 'call-id-local-reject'
+  const CALLER_ID = 'caller-local-reject'
 
-    ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : CALLER_ID,
+    participants : [ CALLER_ID, 'bot-self' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  puppet.callReject = sandbox.stub().resolves(undefined)
 
-    const contact = (wechaty.Contact as typeof ContactImpl).load('peer-ttl-no-listener')
-    const call    = await contact.call()
-    // Deliberately NO call.on('error') here: this is the default user path.
+  let incoming: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { incoming = c })
 
-    t.doesNotThrow(
-      () => clock.tick(60_001),
-      'TTL expiry must not throw when no error listener is attached',
-    )
-    await new Promise(resolve => setImmediate(resolve))
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    timestamp : 1,
+  } as PUPPET.payloads.EventCall)
+  await flush()
 
-    t.equal(call.status(), 'ended', 'status should still be ended after TTL expiry')
+  t.ok(incoming, 'should receive incoming call')
+  t.ok((wechaty as any).__callPool.has(CALL_ID), 'pool should contain call before reject')
 
-    await wechaty.stop()
-  } finally {
-    clock.restore()
-  }
+  let endedEmitted = false
+  let botEndedCount = 0
+  incoming!.on('ended', () => { endedEmitted = true })
+  wechaty.on('call-ended', (c: CallInterface) => { if (c.id === CALL_ID) botEndedCount++ })
+
+  await incoming!.reject('busy')
+
+  t.ok(endedEmitted, "object 'ended' should fire after local reject()")
+  t.equal(botEndedCount, 1, "bot 'call-ended' should fire exactly once after local reject()")
+  t.notOk((wechaty as any).__callPool.has(CALL_ID), 'call should be evicted from pool after reject()')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test("local cancel() evicts from pool and emits object 'ended' + bot 'call-ended'", async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-local-cancel'
+  const PEER_ID = 'peer-local-cancel'
+
+  puppet.callInvite = sandbox.stub().resolves(CALL_ID)
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', PEER_ID ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  puppet.callCancel = sandbox.stub().resolves(undefined)
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
+  const call    = await contact.call()
+
+  t.ok((wechaty as any).__callPool.has(CALL_ID), 'pool should contain call before cancel')
+
+  let endedEmitted = false
+  let botEndedCount = 0
+  call.on('ended', () => { endedEmitted = true })
+  wechaty.on('call-ended', (c: CallInterface) => { if (c.id === CALL_ID) botEndedCount++ })
+
+  await call.cancel()
+
+  t.ok(endedEmitted, "object 'ended' should fire after local cancel()")
+  t.equal(botEndedCount, 1, "bot 'call-ended' should fire exactly once after local cancel()")
+  t.notOk((wechaty as any).__callPool.has(CALL_ID), 'call should be evicted from pool after cancel()')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test("local hangup() evicts from pool and emits object 'ended' + bot 'call-ended'", async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-local-hangup'
+  const PEER_ID = 'peer-local-hangup'
+
+  puppet.callInvite = sandbox.stub().resolves(CALL_ID)
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', PEER_ID ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  puppet.callHangup = sandbox.stub().resolves(undefined)
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
+  const call    = await contact.call()
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Accept,
+    contactId : PEER_ID,
+    timestamp : 2,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+
+  t.equal(call.status(), 'connected', 'prerequisite: call should be connected')
+  t.ok((wechaty as any).__callPool.has(CALL_ID), 'pool should contain call before hangup')
+
+  let endedEmitted = false
+  let botEndedCount = 0
+  call.on('ended', () => { endedEmitted = true })
+  wechaty.on('call-ended', (c: CallInterface) => { if (c.id === CALL_ID) botEndedCount++ })
+
+  await call.hangup('done')
+
+  t.ok(endedEmitted, "object 'ended' should fire after local hangup()")
+  t.equal(botEndedCount, 1, "bot 'call-ended' should fire exactly once after local hangup()")
+  t.notOk((wechaty as any).__callPool.has(CALL_ID), 'call should be evicted from pool after hangup()')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+// ---------------------------------------------------------------------------
+// 14. dirty(Call) refreshes user-layer __payload
+// ---------------------------------------------------------------------------
+
+test('dirty(Call) refreshes user-layer payload so getters see new value', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID   = 'call-id-dirty'
+  const CALLER_ID = 'caller-dirty'
+
+  // First pull returns Audio; subsequent pulls return Video, simulating a
+  // server-side media switch (e.g. add() upgraded the call).
+  let pulls = 0
+  puppet.callPayload = sandbox.stub().callsFake(async (id: string) => {
+    pulls++
+    await new Promise(setImmediate)
+    return {
+      id,
+      starter      : CALLER_ID,
+      participants : [ CALLER_ID, 'bot-self' ],
+      media        : pulls === 1 ? PUPPET.types.CallMediaType.Audio : PUPPET.types.CallMediaType.Video,
+      startTime    : 1,
+    } as PUPPET.payloads.Call
+  })
+  puppet.callPayloadDirty = sandbox.stub().resolves(undefined)
+
+  let incoming: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { incoming = c })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    timestamp : 1,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+
+  t.ok(incoming, 'should receive incoming call')
+  t.equal(incoming!.media(), PUPPET.types.CallMediaType.Audio, 'initial media should be Audio')
+
+  ;(puppet as any).emit('dirty', {
+    payloadType : PUPPET.types.Payload.Call,
+    payloadId   : CALL_ID,
+  } as PUPPET.payloads.EventDirty)
+  await flush()
+
+  t.equal(incoming!.media(), PUPPET.types.CallMediaType.Video, 'media should reflect refreshed payload after dirty')
+  t.ok((puppet.callPayloadDirty as any).called, 'puppet.callPayloadDirty should be invoked')
+
+  await wechaty.stop()
+  sandbox.restore()
 })

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -160,20 +160,11 @@ test('incoming call.accept() sends Accept signal and transitions to connected', 
   const CALL_ID   = 'call-id-accept-test'
   const CALLER_ID = 'caller-id'
 
-  // Trigger incoming call
-  ;(puppet as any).emit('call', {
-    callId    : CALL_ID,
-    signal    : PUPPET.types.CallSignal.Invite,
-    contactId : CALLER_ID,
-  } as PUPPET.payloads.EventCall)
-  await new Promise(resolve => setImmediate(resolve))
-
   let incomingCall: CallInterface | undefined
   wechaty.on('call', (c: CallInterface) => { incomingCall = c })
 
-  // Re-emit to capture the reference
   ;(puppet as any).emit('call', {
-    callId    : CALL_ID + '-2',
+    callId    : CALL_ID,
     signal    : PUPPET.types.CallSignal.Invite,
     contactId : CALLER_ID,
   } as PUPPET.payloads.EventCall)
@@ -185,6 +176,72 @@ test('incoming call.accept() sends Accept signal and transitions to connected', 
   t.equal(incomingCall!.status(), 'connected', 'status should be connected after accept()')
   const acceptCall = callControlStub.getCalls().find(c => c.args[0]?.signal === PUPPET.types.CallSignal.Accept)
   t.ok(acceptCall, 'callControl should have been called with Accept')
+
+  await wechaty.stop()
+})
+
+// ---------------------------------------------------------------------------
+// 4b. duplicate Invite for same callId is silently dropped (M1 guard)
+// ---------------------------------------------------------------------------
+
+test('duplicate Invite for same callId is ignored: call event fires once, original call survives', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID   = 'call-id-dup-invite'
+  const CALLER_ID = 'caller-dup'
+
+  let callEventCount = 0
+  let firstCall: CallInterface | undefined
+
+  wechaty.on('call', (c: CallInterface) => {
+    callEventCount++
+    if (!firstCall) {
+      firstCall = c
+    }
+  })
+
+  // First Invite — should create a call and emit 'call'
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    media     : PUPPET.types.CallMediaType.Audio,
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.equal(callEventCount, 1, "'call' event should fire exactly once after first Invite")
+  t.ok(firstCall, 'first Call instance should be captured')
+  t.equal(firstCall!.status(), 'ringing', 'first call should be in ringing state')
+
+  // Second Invite with the same callId — guard should drop it silently
+  let errorEmitted = false
+  wechaty.on('error', () => { errorEmitted = true })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    media     : PUPPET.types.CallMediaType.Audio,
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.equal(callEventCount, 1, "'call' event must not fire again for duplicate Invite")
+  t.notOk(errorEmitted, 'no error event should be emitted for a duplicate Invite')
+
+  // The original call instance must still be alive and responsive to subsequent signals
+  const hangupEmitted = await new Promise<boolean>(resolve => {
+    firstCall!.on('hangup', () => resolve(true))
+    ;(puppet as any).emit('call', {
+      callId    : CALL_ID,
+      signal    : PUPPET.types.CallSignal.Cancel,
+      contactId : CALLER_ID,
+    } as PUPPET.payloads.EventCall)
+    setTimeout(() => resolve(false), 100)
+  })
+
+  t.ok(hangupEmitted, 'original Call instance should still handle subsequent signals after duplicate was dropped')
+  t.equal(firstCall!.status(), 'ended', 'original call should reach ended state after Cancel signal')
 
   await wechaty.stop()
 })

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -1,0 +1,299 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/**
+ * Tests for the Call first-class object and its lifecycle state machine.
+ */
+
+import {
+  test,
+  sinon,
+}             from 'tstest'
+
+import * as PUPPET    from '@juzi/wechaty-puppet'
+import { PuppetMock } from '@juzi/wechaty-puppet-mock'
+import { WechatyBuilder } from '../wechaty-builder.js'
+import type { CallInterface } from './call.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildWechaty () {
+  const puppet  = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+  return { puppet, wechaty }
+}
+
+async function startAndLogin (puppet: any, wechaty: any, userId = 'bot-self') {
+  sandbox.stub(puppet, 'contactPayload').callsFake(async (id: string) => {
+    await new Promise(setImmediate)
+    return { id, name: id } as PUPPET.payloads.Contact
+  })
+  sandbox.stub(puppet, 'contactSearch').callsFake(async (...args: any[]) => {
+    await new Promise(setImmediate)
+    return [ args[0]?.id ?? userId ]
+  })
+  await wechaty.start()
+  await puppet.login(userId)
+}
+
+let sandbox: sinon.SinonSandbox
+
+test.before(() => {
+  sandbox = sinon.createSandbox()
+})
+
+test.after(() => {
+  sandbox.restore()
+})
+
+// ---------------------------------------------------------------------------
+// 1. contact.call() → returns Call with correct initial state
+// ---------------------------------------------------------------------------
+
+test('contact.call() returns an outgoing Call with status=calling and media=audio', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+  const PEER_ID = 'peer-contact-id'
+  const contact = wechaty.Contact.load(PEER_ID)
+
+  const call: CallInterface = await contact.call()
+
+  t.equal(call.direction(), 'outgoing', 'should be outgoing')
+  t.equal(call.status(), 'calling', 'initial status should be calling')
+  t.equal(call.media(), PUPPET.types.CallMediaType.Audio, 'default media should be audio')
+  t.ok(call.id, 'callId should be non-empty')
+
+  t.ok(callControlStub.calledOnce, 'puppet.callControl should have been called once')
+  const [ controlPayload ] = callControlStub.firstCall.args
+  t.equal(controlPayload.signal, PUPPET.types.CallSignal.Invite, 'should send Invite signal')
+  t.equal(controlPayload.peerId, PEER_ID, 'peerId should match contact id')
+  t.equal(controlPayload.media, PUPPET.types.CallMediaType.Audio, 'media should match')
+
+  await wechaty.stop()
+})
+
+// ---------------------------------------------------------------------------
+// 2. incoming call via puppet 'call' event with signal=Invite
+// ---------------------------------------------------------------------------
+
+test('incoming call: puppet emit call/Invite → bot emits call event, direction=incoming, status=ringing', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID     = 'call-id-incoming'
+  const CALLER_ID   = 'caller-contact-id'
+
+  let receivedCall: CallInterface | undefined
+
+  wechaty.on('call', (call: CallInterface) => {
+    receivedCall = call
+  })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+    media     : PUPPET.types.CallMediaType.Video,
+  } as PUPPET.payloads.EventCall)
+
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.ok(receivedCall, 'bot should emit call event')
+  t.equal(receivedCall!.id, CALL_ID, 'call.id should match')
+  t.equal(receivedCall!.direction(), 'incoming', 'should be incoming')
+  t.equal(receivedCall!.status(), 'ringing', 'initial status should be ringing')
+  t.equal(receivedCall!.contact().id, CALLER_ID, 'contact().id should match caller')
+
+  await wechaty.stop()
+})
+
+// ---------------------------------------------------------------------------
+// 3. outgoing call: ringing and accept signals cause status transitions + events
+// ---------------------------------------------------------------------------
+
+test('outgoing call: ringing signal → status=ringing + emit ringing; accept signal → status=connected + emit accept', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+  const PEER_ID = 'peer-id-outgoing'
+  const contact = wechaty.Contact.load(PEER_ID)
+  const call: CallInterface = await contact.call()
+
+  const ringingEmitted = await new Promise<boolean>(resolve => {
+    call.on('ringing', () => resolve(true))
+    ;(puppet as any).emit('call', {
+      callId    : call.id,
+      signal    : PUPPET.types.CallSignal.Ringing,
+      contactId : PEER_ID,
+    } as PUPPET.payloads.EventCall)
+    setTimeout(() => resolve(false), 100)
+  })
+
+  t.ok(ringingEmitted, 'call should emit ringing')
+  t.equal(call.status(), 'ringing', 'status should be ringing after Ringing signal')
+
+  const acceptEmitted = await new Promise<boolean>(resolve => {
+    call.on('accept', () => resolve(true))
+    ;(puppet as any).emit('call', {
+      callId    : call.id,
+      signal    : PUPPET.types.CallSignal.Accept,
+      contactId : PEER_ID,
+    } as PUPPET.payloads.EventCall)
+    setTimeout(() => resolve(false), 100)
+  })
+
+  t.ok(acceptEmitted, 'call should emit accept')
+  t.equal(call.status(), 'connected', 'status should be connected after Accept signal')
+
+  await wechaty.stop()
+})
+
+// ---------------------------------------------------------------------------
+// 4. incoming call.accept() → callControl receives Accept + status=connected
+//    illegal call.accept() on outgoing → rejects
+// ---------------------------------------------------------------------------
+
+test('incoming call.accept() sends Accept signal and transitions to connected', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+  const CALL_ID   = 'call-id-accept-test'
+  const CALLER_ID = 'caller-id'
+
+  // Trigger incoming call
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  let incomingCall: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { incomingCall = c })
+
+  // Re-emit to capture the reference
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID + '-2',
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.ok(incomingCall, 'should have received an incoming call')
+  await incomingCall!.accept()
+
+  t.equal(incomingCall!.status(), 'connected', 'status should be connected after accept()')
+  const acceptCall = callControlStub.getCalls().find(c => c.args[0]?.signal === PUPPET.types.CallSignal.Accept)
+  t.ok(acceptCall, 'callControl should have been called with Accept')
+
+  await wechaty.stop()
+})
+
+test('outgoing call.accept() throws an error (invalid direction)', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+  const contact = wechaty.Contact.load('some-peer')
+  const call    = await contact.call()
+
+  await t.rejects(
+    call.accept(),
+    /invalid/i,
+    'accept() on outgoing call should throw',
+  )
+
+  await wechaty.stop()
+})
+
+// ---------------------------------------------------------------------------
+// 5. peer Cancel → callee call emits 'hangup' + status=ended + pool cleanup
+// ---------------------------------------------------------------------------
+
+test('outgoing Cancel signal received by callee → call emits hangup, status=ended, pool cleanup', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID   = 'call-id-cancel-test'
+  const CALLER_ID = 'caller-cancel'
+
+  let incomingCall: CallInterface | undefined
+  wechaty.on('call', (c: CallInterface) => { incomingCall = c })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : CALLER_ID,
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.ok(incomingCall, 'should have received incoming call')
+
+  const hangupEmitted = await new Promise<boolean>(resolve => {
+    incomingCall!.on('hangup', () => resolve(true))
+    ;(puppet as any).emit('call', {
+      callId    : CALL_ID,
+      signal    : PUPPET.types.CallSignal.Cancel,
+      contactId : CALLER_ID,
+    } as PUPPET.payloads.EventCall)
+    setTimeout(() => resolve(false), 100)
+  })
+
+  t.ok(hangupEmitted, "Cancel from peer should emit 'hangup' on callee's call")
+  t.equal(incomingCall!.status(), 'ended', 'status should be ended')
+
+  // After ended, a subsequent signal for the same callId should emit an error
+  let errorEmitted = false
+  wechaty.on('error', () => { errorEmitted = true })
+
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Hangup,
+    contactId : CALLER_ID,
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.ok(errorEmitted, 'bot should emit error for unknown callId after pool cleanup')
+
+  await wechaty.stop()
+})
+
+// ---------------------------------------------------------------------------
+// 6. call.hangup() on connected call
+// ---------------------------------------------------------------------------
+
+test('call.hangup() on connected call sends Hangup and transitions to ended', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+  const contact = wechaty.Contact.load('peer-hangup-test')
+  const call    = await contact.call()
+
+  // Simulate peer accepting the call
+  ;(puppet as any).emit('call', {
+    callId    : call.id,
+    signal    : PUPPET.types.CallSignal.Accept,
+    contactId : 'peer-hangup-test',
+  } as PUPPET.payloads.EventCall)
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.equal(call.status(), 'connected', 'status should be connected')
+
+  await call.hangup()
+
+  t.equal(call.status(), 'ended', 'status should be ended after hangup()')
+  const hangupCall = callControlStub.getCalls().find(c => c.args[0]?.signal === PUPPET.types.CallSignal.Hangup)
+  t.ok(hangupCall, 'callControl should have been called with Hangup signal')
+
+  await wechaty.stop()
+})

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -47,7 +47,9 @@ test('contact.call() returns an outgoing Call with status=calling and media=audi
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+  const callControlStub = sandbox.stub().resolves(undefined)
+
+  ;(puppet as any).callControl = callControlStub
 
   const PEER_ID = 'peer-contact-id'
   const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
@@ -111,7 +113,7 @@ test('outgoing call: ringing signal → status=ringing + emit ringing; accept si
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+  ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
 
   const PEER_ID = 'peer-id-outgoing'
   const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
@@ -155,7 +157,9 @@ test('incoming call.accept() sends Accept signal and transitions to connected', 
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+  const callControlStub = sandbox.stub().resolves(undefined)
+
+  ;(puppet as any).callControl = callControlStub
 
   const CALL_ID   = 'call-id-accept-test'
   const CALLER_ID = 'caller-id'
@@ -250,7 +254,7 @@ test('outgoing call.accept() throws an error (invalid direction)', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+  ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
 
   const contact = (wechaty.Contact as typeof ContactImpl).load('some-peer')
   const call    = await contact.call()
@@ -324,7 +328,9 @@ test('call.hangup() on connected call sends Hangup and transitions to ended', as
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+  const callControlStub = sandbox.stub().resolves(undefined)
+
+  ;(puppet as any).callControl = callControlStub
 
   const contact = (wechaty.Contact as typeof ContactImpl).load('peer-hangup-test')
   const call    = await contact.call()
@@ -356,7 +362,9 @@ test('call.hangup() rejects when callControl fails but status transitions to end
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  const callControlStub = sandbox.stub(puppet, 'callControl' as any)
+  const callControlStub = sandbox.stub()
+
+  ;(puppet as any).callControl = callControlStub
 
   const contact = (wechaty.Contact as typeof ContactImpl).load('peer-hangup-fail')
   // First call is the Invite – let it succeed.
@@ -409,7 +417,7 @@ test('wechaty.stop() clears the call pool', async t => {
   const { puppet, wechaty } = buildWechaty()
   await startAndLogin(puppet, wechaty)
 
-  sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+  ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
 
   const contact = (wechaty.Contact as typeof ContactImpl).load('peer-stop-test')
   // Place an outgoing call that is never answered.
@@ -436,7 +444,7 @@ test('Call TTL force-ends an unanswered outgoing call and emits error', async t 
     const { puppet, wechaty } = buildWechaty()
     await startAndLogin(puppet, wechaty, 'bot-ttl-test')
 
-    sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+    ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
 
     const contact = (wechaty.Contact as typeof ContactImpl).load('peer-ttl-test')
     const call    = await contact.call()
@@ -473,7 +481,7 @@ test('Call TTL reaps an ignored call without error listeners and without throwin
     const { puppet, wechaty } = buildWechaty()
     await startAndLogin(puppet, wechaty, 'bot-ttl-no-listener')
 
-    sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+    ;(puppet as any).callControl = sandbox.stub().resolves(undefined)
 
     const contact = (wechaty.Contact as typeof ContactImpl).load('peer-ttl-no-listener')
     const call    = await contact.call()

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -12,6 +12,7 @@ import * as PUPPET    from '@juzi/wechaty-puppet'
 import { PuppetMock } from '@juzi/wechaty-puppet-mock'
 import { WechatyBuilder } from '../wechaty-builder.js'
 import type { CallInterface } from './call.js'
+import type { ContactImpl } from './contact.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,15 +37,7 @@ async function startAndLogin (puppet: any, wechaty: any, userId = 'bot-self') {
   await puppet.login(userId)
 }
 
-let sandbox: sinon.SinonSandbox
-
-test.before(() => {
-  sandbox = sinon.createSandbox()
-})
-
-test.after(() => {
-  sandbox.restore()
-})
+const sandbox = sinon.createSandbox()
 
 // ---------------------------------------------------------------------------
 // 1. contact.call() → returns Call with correct initial state
@@ -57,7 +50,7 @@ test('contact.call() returns an outgoing Call with status=calling and media=audi
   const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
 
   const PEER_ID = 'peer-contact-id'
-  const contact = wechaty.Contact.load(PEER_ID)
+  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
 
   const call: CallInterface = await contact.call()
 
@@ -121,7 +114,7 @@ test('outgoing call: ringing signal → status=ringing + emit ringing; accept si
   sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
 
   const PEER_ID = 'peer-id-outgoing'
-  const contact = wechaty.Contact.load(PEER_ID)
+  const contact = (wechaty.Contact as typeof ContactImpl).load(PEER_ID)
   const call: CallInterface = await contact.call()
 
   const ringingEmitted = await new Promise<boolean>(resolve => {
@@ -202,7 +195,7 @@ test('outgoing call.accept() throws an error (invalid direction)', async t => {
 
   sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
 
-  const contact = wechaty.Contact.load('some-peer')
+  const contact = (wechaty.Contact as typeof ContactImpl).load('some-peer')
   const call    = await contact.call()
 
   await t.rejects(
@@ -276,7 +269,7 @@ test('call.hangup() on connected call sends Hangup and transitions to ended', as
 
   const callControlStub = sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
 
-  const contact = wechaty.Contact.load('peer-hangup-test')
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer-hangup-test')
   const call    = await contact.call()
 
   // Simulate peer accepting the call

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -402,3 +402,36 @@ test('Call TTL force-ends an unanswered outgoing call and emits error', async t 
     clock.restore()
   }
 })
+
+// ---------------------------------------------------------------------------
+// 8. TTL expiry must not crash the process when nobody listens for 'error'
+//    (Node throws synchronously on unhandled 'error' emit inside the timer
+//    callback, which would take down the whole bot process).
+// ---------------------------------------------------------------------------
+
+test('Call TTL reaps an ignored call without error listeners and without throwing', async t => {
+  const clock = sinon.useFakeTimers({ toFake: [ 'setTimeout' ] })
+
+  try {
+    const { puppet, wechaty } = buildWechaty()
+    await startAndLogin(puppet, wechaty, 'bot-ttl-no-listener')
+
+    sandbox.stub(puppet, 'callControl' as any).resolves(undefined)
+
+    const contact = (wechaty.Contact as typeof ContactImpl).load('peer-ttl-no-listener')
+    const call    = await contact.call()
+    // Deliberately NO call.on('error') here: this is the default user path.
+
+    t.doesNotThrow(
+      () => clock.tick(60_001),
+      'TTL expiry must not throw when no error listener is attached',
+    )
+    await new Promise(resolve => setImmediate(resolve))
+
+    t.equal(call.status(), 'ended', 'status should still be ended after TTL expiry')
+
+    await wechaty.stop()
+  } finally {
+    clock.restore()
+  }
+})

--- a/src/user-modules/call.ts
+++ b/src/user-modules/call.ts
@@ -87,7 +87,12 @@ class CallMixin extends CallMixinBase {
     this.__ttlTimer = setTimeout(() => {
       if (this.__status !== 'connected' && this.__status !== 'ended') {
         log.warn('Call', '%s ttl expired in status=%s, force ending', this.id, this.__status)
-        this.emit('error', new Error(`Call ${this.id} timed out in ${this.__status} state`))
+        // Node throws synchronously on 'error' emit without listeners, which would
+        // crash the process from this timer callback. Reaping must never depend on
+        // user code having subscribed to 'error'.
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', new Error(`Call ${this.id} timed out in ${this.__status} state`))
+        }
         this.__transitionTo('ended')
       }
     }, CALL_RINGING_TTL_MS)

--- a/src/user-modules/call.ts
+++ b/src/user-modules/call.ts
@@ -23,6 +23,13 @@ import type { ContactImpl, ContactInterface } from './contact.js'
 export type CallStatus    = 'calling' | 'ringing' | 'connected' | 'ended'
 export type CallDirection = 'outgoing' | 'incoming'
 
+/**
+ * How long a call may stay in a non-terminal, pre-connected state before
+ * being force-ended. Applies to 'calling' and 'ringing' only; connected
+ * calls may legitimately last hours and are not subject to this TTL.
+ */
+const CALL_RINGING_TTL_MS = 60 * 1000
+
 interface CallConstructorOptions {
   readonly id        : string
   readonly peerId    : string
@@ -55,6 +62,7 @@ class CallMixin extends CallMixinBase {
   private __status    : CallStatus
   private __direction : CallDirection
   private __onEnded   : (callId: string) => void
+  private __ttlTimer  : ReturnType<typeof setTimeout> | undefined
 
   constructor (options: CallConstructorOptions) {
     super()
@@ -73,6 +81,17 @@ class CallMixin extends CallMixinBase {
     }
 
     log.verbose('Call', 'constructor(%s, dir=%s, media=%s)', this.id, this.__direction, this.__media)
+
+    // Guard pre-connected states against abandoned or unanswered calls.
+    // 'connected' is intentionally excluded: calls can legitimately last hours.
+    this.__ttlTimer = setTimeout(() => {
+      if (this.__status !== 'connected' && this.__status !== 'ended') {
+        log.warn('Call', '%s ttl expired in status=%s, force ending', this.id, this.__status)
+        this.emit('error', new Error(`Call ${this.id} timed out in ${this.__status} state`))
+        this.__transitionTo('ended')
+      }
+    }, CALL_RINGING_TTL_MS)
+    this.__ttlTimer.unref()
   }
 
   /** The remote party: callee when outgoing, caller when incoming. */
@@ -130,14 +149,18 @@ class CallMixin extends CallMixinBase {
       )
     }
 
-    await this.wechaty.puppet.callControl({
-      callId : this.id,
-      signal : PUPPET.types.CallSignal.Reject,
-      peerId : this.__peerId,
-      reason,
-    })
-
-    this.__transitionTo('ended')
+    try {
+      await this.wechaty.puppet.callControl({
+        callId : this.id,
+        signal : PUPPET.types.CallSignal.Reject,
+        peerId : this.__peerId,
+        media  : this.__media,
+        reason,
+      })
+    } finally {
+      // local side has decided to abandon; terminate locally even if the signal failed to send
+      this.__transitionTo('ended')
+    }
   }
 
   /**
@@ -152,14 +175,18 @@ class CallMixin extends CallMixinBase {
       )
     }
 
-    await this.wechaty.puppet.callControl({
-      callId : this.id,
-      signal : PUPPET.types.CallSignal.Hangup,
-      peerId : this.__peerId,
-      reason,
-    })
-
-    this.__transitionTo('ended')
+    try {
+      await this.wechaty.puppet.callControl({
+        callId : this.id,
+        signal : PUPPET.types.CallSignal.Hangup,
+        peerId : this.__peerId,
+        media  : this.__media,
+        reason,
+      })
+    } finally {
+      // local side has decided to abandon; terminate locally even if the signal failed to send
+      this.__transitionTo('ended')
+    }
   }
 
   /**
@@ -180,13 +207,17 @@ class CallMixin extends CallMixinBase {
       )
     }
 
-    await this.wechaty.puppet.callControl({
-      callId : this.id,
-      signal : PUPPET.types.CallSignal.Cancel,
-      peerId : this.__peerId,
-    })
-
-    this.__transitionTo('ended')
+    try {
+      await this.wechaty.puppet.callControl({
+        callId : this.id,
+        signal : PUPPET.types.CallSignal.Cancel,
+        peerId : this.__peerId,
+        media  : this.__media,
+      })
+    } finally {
+      // local side has decided to abandon; terminate locally even if the signal failed to send
+      this.__transitionTo('ended')
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -212,7 +243,7 @@ class CallMixin extends CallMixinBase {
         break
 
       case PUPPET.types.CallSignal.Accept:
-        if (this.__status === 'calling' || this.__status === 'ringing') {
+        if (this.__direction === 'outgoing' && (this.__status === 'calling' || this.__status === 'ringing')) {
           this.__transitionTo('connected')
           this.emit('accept')
         }
@@ -248,6 +279,12 @@ class CallMixin extends CallMixinBase {
   private __transitionTo (nextStatus: CallStatus): void {
     log.verbose('Call', '__transitionTo(%s) from %s', nextStatus, this.__status)
     this.__status = nextStatus
+    if (nextStatus === 'connected' || nextStatus === 'ended') {
+      if (this.__ttlTimer) {
+        clearTimeout(this.__ttlTimer)
+        this.__ttlTimer = undefined
+      }
+    }
     if (nextStatus === 'ended') {
       this.__onEnded(this.id)
     }

--- a/src/user-modules/call.ts
+++ b/src/user-modules/call.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto'
-
 import * as PUPPET from '@juzi/wechaty-puppet'
 
 import type { Constructor } from 'clone-class'
@@ -23,22 +21,11 @@ import type { ContactImpl, ContactInterface } from './contact.js'
 export type CallStatus    = 'calling' | 'ringing' | 'connected' | 'ended'
 export type CallDirection = 'outgoing' | 'incoming'
 
-/**
- * How long a call may stay in a non-terminal, pre-connected state before
- * being force-ended. Applies to 'calling' and 'ringing' only; connected
- * calls may legitimately last hours and are not subject to this TTL.
- */
-const CALL_RINGING_TTL_MS = 60 * 1000
-
 interface CallConstructorOptions {
   readonly id        : string
-  readonly peerId    : string
-  readonly media     : PUPPET.types.CallMediaType
   readonly direction : CallDirection
-  /** If omitted the status is derived: outgoing→calling, incoming→ringing */
+  /** If omitted the status is derived: outgoing → calling, incoming → ringing */
   readonly status?   : CallStatus
-  /** Called when the call transitions to ended so the registry can clean up */
-  readonly onEnded   : (callId: string) => void
 }
 
 const CallMixinBase = wechatifyMixin(CallEventEmitter)
@@ -48,72 +35,116 @@ const CallMixinBase = wechatifyMixin(CallEventEmitter)
  *
  * A Call is a first-class citizen alongside Message and Contact.
  * It models the signaling lifecycle of a call (not the media connection itself;
- * media runs peer-to-peer and is associated only by `callId`).
+ * media runs through a direct gateway link addressed by callId).
  *
- * Outgoing: obtain via `contact.call()`.
+ * Outgoing: obtain via `bot.call([contact, ...])` or `contact.call()`.
  * Incoming: received as the argument of the `bot.on('call', …)` event.
+ *
+ * State (media, roster, lifecycle timestamps) is hydrated from the puppet via
+ * `ready()` / `sync()`. The dirty stream (`Dirty.Call`) drives cache invalidation.
  */
 class CallMixin extends CallMixinBase {
 
   readonly id : string
 
-  private __peerId    : string
-  private __media     : PUPPET.types.CallMediaType
-  private __status    : CallStatus
-  private __direction : CallDirection
-  private __onEnded   : (callId: string) => void
-  private __ttlTimer  : ReturnType<typeof setTimeout> | undefined
+  private __direction    : CallDirection
+  private __status       : CallStatus
+  private __payload?     : PUPPET.payloads.Call
+  private __endedEmitted = false
 
   constructor (options: CallConstructorOptions) {
     super()
 
     this.id          = options.id
-    this.__peerId    = options.peerId
-    this.__media     = options.media
     this.__direction = options.direction
-    this.__onEnded   = options.onEnded
+    this.__status    = options.status ?? (options.direction === 'outgoing' ? 'calling' : 'ringing')
 
-    // Derive initial status from direction when not explicitly provided.
-    if (options.status !== undefined) {
-      this.__status = options.status
-    } else {
-      this.__status = options.direction === 'outgoing' ? 'calling' : 'ringing'
-    }
-
-    log.verbose('Call', 'constructor(%s, dir=%s, media=%s)', this.id, this.__direction, this.__media)
-
-    // Guard pre-connected states against abandoned or unanswered calls.
-    // 'connected' is intentionally excluded: calls can legitimately last hours.
-    this.__ttlTimer = setTimeout(() => {
-      if (this.__status !== 'connected' && this.__status !== 'ended') {
-        log.warn('Call', '%s ttl expired in status=%s, force ending', this.id, this.__status)
-        // Node throws synchronously on 'error' emit without listeners, which would
-        // crash the process from this timer callback. Reaping must never depend on
-        // user code having subscribed to 'error'.
-        if (this.listenerCount('error') > 0) {
-          this.emit('error', new Error(`Call ${this.id} timed out in ${this.__status} state`))
-        }
-        this.__transitionTo('ended')
-      }
-    }, CALL_RINGING_TTL_MS)
-    this.__ttlTimer.unref()
+    log.verbose('Call', 'constructor(%s, dir=%s, status=%s)', this.id, this.__direction, this.__status)
   }
 
-  /** The remote party: callee when outgoing, caller when incoming. */
-  contact (): ContactInterface {
-    return (this.wechaty.Contact as typeof ContactImpl).load(this.__peerId)
-  }
+  direction (): CallDirection { return this.__direction }
+  status    (): CallStatus    { return this.__status }
 
+  /**
+   * The media type of the call (audio | video).
+   * Requires the payload to be hydrated; throws otherwise.
+   */
   media (): PUPPET.types.CallMediaType {
-    return this.__media
+    if (!this.__payload) {
+      throw new Error(`Call ${this.id} not ready: call ready() first`)
+    }
+    return this.__payload.media
   }
 
-  status (): CallStatus {
-    return this.__status
+  /**
+   * When the call was initiated (protocol-side clock).
+   * Requires the payload to be hydrated; throws otherwise.
+   */
+  startTime (): Date {
+    if (!this.__payload) {
+      throw new Error(`Call ${this.id} not ready: call ready() first`)
+    }
+    return new Date(this.__payload.startTime)
   }
 
-  direction (): CallDirection {
-    return this.__direction
+  /**
+   * When the call terminated. Becomes defined once a dirty refresh observes
+   * the protocol-side endTime; returns undefined while the call is live.
+   */
+  endTime (): Date | undefined {
+    if (!this.__payload?.endTime) {
+      return undefined
+    }
+    return new Date(this.__payload.endTime)
+  }
+
+  /**
+   * The participant who started the call. Returns undefined when the protocol
+   * payload does not identify a starter (rare; defensive).
+   */
+  async starter (): Promise<ContactInterface | undefined> {
+    if (!this.__payload) {
+      await this.ready()
+    }
+    const starterId = this.__payload!.starter
+    if (!starterId) {
+      return undefined
+    }
+    return (this.wechaty.Contact as typeof ContactImpl).find({ id: starterId })
+  }
+
+  /**
+   * Current participant roster. The list is maintained server-side and refreshed
+   * via the dirty mechanism; consumers should expect this to change between calls.
+   */
+  async participants (): Promise<ContactInterface[]> {
+    if (!this.__payload) {
+      await this.ready()
+    }
+    const found = await Promise.all(
+      this.__payload!.participants.map(id => (this.wechaty.Contact as typeof ContactImpl).find({ id })),
+    )
+    return found.filter((c): c is ContactInterface => !!c)
+  }
+
+  /**
+   * Hydrate the call payload from the puppet. A no-op if already hydrated
+   * unless `forceSync` is true.
+   */
+  async ready (forceSync = false): Promise<void> {
+    if (!forceSync && this.__payload) {
+      return
+    }
+    this.__payload = await this.wechaty.puppet.callPayload(this.id)
+  }
+
+  /**
+   * Force-invalidate the cached payload and re-pull it. Used after a dirty
+   * signal or when the local view is suspected to be stale.
+   */
+  async sync (): Promise<void> {
+    await this.wechaty.puppet.callPayloadDirty(this.id)
+    await this.ready(true)
   }
 
   // ---------------------------------------------------------------------------
@@ -121,8 +152,7 @@ class CallMixin extends CallMixinBase {
   // ---------------------------------------------------------------------------
 
   /**
-   * Accept an incoming call.
-   * Only valid when direction=incoming and status=ringing.
+   * Accept an incoming call. Only valid when direction=incoming, status=ringing.
    */
   async accept (): Promise<void> {
     if (this.__direction !== 'incoming' || this.__status !== 'ringing') {
@@ -131,20 +161,14 @@ class CallMixin extends CallMixinBase {
         + 'Only valid for incoming calls in ringing state.',
       )
     }
-
-    await this.wechaty.puppet.callControl({
-      callId : this.id,
-      signal : PUPPET.types.CallSignal.Accept,
-      peerId : this.__peerId,
-      media  : this.__media,
-    })
-
+    await this.wechaty.puppet.callAccept(this.id)
     this.__transitionTo('connected')
   }
 
   /**
-   * Reject an incoming call.
-   * Only valid when direction=incoming and status=ringing.
+   * Reject an incoming call. Only valid when direction=incoming, status=ringing.
+   * Local state transitions to 'ended' regardless of whether the protocol
+   * acknowledgement reaches the peer.
    */
   async reject (reason?: string): Promise<void> {
     if (this.__direction !== 'incoming' || this.__status !== 'ringing') {
@@ -153,50 +177,16 @@ class CallMixin extends CallMixinBase {
         + 'Only valid for incoming calls in ringing state.',
       )
     }
-
     try {
-      await this.wechaty.puppet.callControl({
-        callId : this.id,
-        signal : PUPPET.types.CallSignal.Reject,
-        peerId : this.__peerId,
-        media  : this.__media,
-        reason,
-      })
+      await this.wechaty.puppet.callReject(this.id, reason)
     } finally {
-      // local side has decided to abandon; terminate locally even if the signal failed to send
-      this.__transitionTo('ended')
-    }
-  }
-
-  /**
-   * Hang up a connected call.
-   * Only valid when status=connected.
-   */
-  async hangup (reason?: string): Promise<void> {
-    if (this.__status !== 'connected') {
-      throw new Error(
-        `Call.hangup() invalid: status=${this.__status}. `
-        + 'Only valid for connected calls.',
-      )
-    }
-
-    try {
-      await this.wechaty.puppet.callControl({
-        callId : this.id,
-        signal : PUPPET.types.CallSignal.Hangup,
-        peerId : this.__peerId,
-        media  : this.__media,
-        reason,
-      })
-    } finally {
-      // local side has decided to abandon; terminate locally even if the signal failed to send
-      this.__transitionTo('ended')
+      this.__finalize()
     }
   }
 
   /**
    * Cancel an outgoing call before it is connected.
-   * Only valid when direction=outgoing and status=calling or ringing.
+   * Only valid when direction=outgoing and status is calling or ringing.
    */
   async cancel (): Promise<void> {
     if (this.__direction !== 'outgoing') {
@@ -211,35 +201,72 @@ class CallMixin extends CallMixinBase {
         + 'Only valid when status is calling or ringing.',
       )
     }
-
     try {
-      await this.wechaty.puppet.callControl({
-        callId : this.id,
-        signal : PUPPET.types.CallSignal.Cancel,
-        peerId : this.__peerId,
-        media  : this.__media,
-      })
+      await this.wechaty.puppet.callCancel(this.id)
     } finally {
-      // local side has decided to abandon; terminate locally even if the signal failed to send
-      this.__transitionTo('ended')
+      this.__finalize()
     }
   }
 
+  /**
+   * Hang up a connected call. Only valid when status=connected.
+   */
+  async hangup (reason?: string): Promise<void> {
+    if (this.__status !== 'connected') {
+      throw new Error(
+        `Call.hangup() invalid: status=${this.__status}. `
+        + 'Only valid for connected calls.',
+      )
+    }
+    try {
+      await this.wechaty.puppet.callHangup(this.id, reason)
+    } finally {
+      this.__finalize()
+    }
+  }
+
+  /**
+   * Invite additional contacts to a live call (group-call growth).
+   */
+  async add (contacts: ContactInterface[]): Promise<void> {
+    if (this.__status === 'ended') {
+      throw new Error('Call.add() invalid: status=ended. Cannot add to a finished call.')
+    }
+    if (contacts.length === 0) {
+      throw new Error('Call.add() requires at least one contact.')
+    }
+    await this.wechaty.puppet.callAdd(this.id, contacts.map(c => c.id))
+  }
+
+  /**
+   * Pull a fresh admission ticket to the direct-to-gateway media path.
+   * Not cached: the credential is short-lived and may pre-allocate a session.
+   */
+  async mediaEndpoint (): Promise<PUPPET.payloads.CallMediaEndpoint> {
+    return this.wechaty.puppet.callMediaEndpoint(this.id)
+  }
+
   // ---------------------------------------------------------------------------
-  // Internal signal handler – called from puppet-mixin
+  // Framework-internal — must not be called from user code.
   // ---------------------------------------------------------------------------
 
   /**
    * Process an inbound call signal from the puppet layer.
-   * This method is framework-internal and must not be called from user code.
+   * Drives state transitions and emits the corresponding object-level event.
+   * Terminal lifecycle (ended) is owned by the puppet-mixin which calls
+   * `__markEnded()` after observing the protocol-side endTime.
    */
-  __handleSignal (payload: PUPPET.payloads.EventCall): void {
+  __handleSignal (
+    signal: PUPPET.types.CallSignal,
+    actor: ContactInterface,
+    reason?: string,
+  ): void {
     if (this.__status === 'ended') {
-      log.warn('Call', '__handleSignal(%s) ignoring signal in ended state', payload.signal)
+      log.warn('Call', '__handleSignal(%s) ignored in ended state for callId=%s', signal, this.id)
       return
     }
 
-    switch (payload.signal) {
+    switch (signal) {
       case PUPPET.types.CallSignal.Ringing:
         if (this.__direction === 'outgoing' && this.__status === 'calling') {
           this.__transitionTo('ringing')
@@ -248,51 +275,84 @@ class CallMixin extends CallMixinBase {
         break
 
       case PUPPET.types.CallSignal.Accept:
-        if (this.__direction === 'outgoing' && (this.__status === 'calling' || this.__status === 'ringing')) {
+        if (this.__status === 'calling' || this.__status === 'ringing') {
           this.__transitionTo('connected')
-          this.emit('accept')
         }
+        this.emit('accept', actor)
         break
 
+      // Reject/Hangup emit BEFORE puppet-mixin's post-handler finalize, so
+      // consumers' handlers observe pre-terminal status. This is safe here
+      // because the callable terminal actions throw under their own guards at
+      // this moment (accept needs ringing, cancel needs calling/ringing,
+      // hangup needs connected). The Cancel case below is the asymmetric
+      // outlier: it MUST finalize first to close a media-acquisition race
+      // window on the receiving side.
       case PUPPET.types.CallSignal.Reject:
-        this.__transitionTo('ended')
-        this.emit('reject', payload.reason)
-        break
-
-      case PUPPET.types.CallSignal.Cancel:
-        // The caller cancelled. From the callee's perspective this means the
-        // call ended. Surface as 'hangup' since there is no 'cancel' user event.
-        this.__transitionTo('ended')
-        this.emit('hangup', payload.reason)
+        this.emit('reject', actor, reason)
         break
 
       case PUPPET.types.CallSignal.Hangup:
-        this.__transitionTo('ended')
-        this.emit('hangup', payload.reason)
+        this.emit('hangup', actor, reason)
+        break
+
+      case PUPPET.types.CallSignal.Cancel:
+        // Intentionally finalizes before emitting 'cancel' so consumers'
+        // cancel handler observes status === 'ended' synchronously. Cancel
+        // signals are always terminal on the receiving side (the caller has
+        // withdrawn), so the status flip should be visible to listeners
+        // before the descriptor event fires. The reverse order would let a
+        // cancel handler observe status === 'ringing' and, worse, call
+        // .accept() through the ringing guard before the puppet-mixin's
+        // post-emit finalize runs.
+        this.__finalize()
+        this.emit('cancel', reason)
         break
 
       default:
-        log.warn('Call', '__handleSignal() unhandled signal: %s', payload.signal)
+        log.warn('Call', '__handleSignal() unhandled signal: %s', signal)
         break
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Private helpers
-  // ---------------------------------------------------------------------------
+  /**
+   * Force the call into the ended terminal state and emit 'ended'.
+   * Called by puppet-mixin after the protocol-side endTime is observed.
+   * Kept as a named entry point distinct from {@link __finalize} so the
+   * puppet-mixin surface reads as intent ("the protocol says this is over").
+   * Idempotent via __finalize.
+   */
+  __markEnded (): void {
+    this.__finalize()
+  }
+
+  /**
+   * Single chokepoint for ending a call: flip the status to ended, emit
+   * the object-level 'ended' event, emit the bot-level 'call-ended' lifecycle
+   * event, and evict the call from the wechaty pool. Guarded by
+   * `__endedEmitted` so that overlapping local-control and puppet-echo paths
+   * cannot double-emit or double-evict.
+   *
+   * Why both event tiers fire here: 'call-ended' is a terminal lifecycle event
+   * (not an action event like 'call-reject'/'call-hangup'), and is independent
+   * of who initiated the termination. Local control paths (reject/cancel/
+   * hangup) and remote-driven paths (puppet signal echo via __finalizeIfEnded)
+   * must both surface it.
+   */
+  private __finalize (): void {
+    if (this.__endedEmitted) {
+      return
+    }
+    this.__endedEmitted = true
+    this.__transitionTo('ended')
+    this.emit('ended')
+    ;(this.wechaty as any).emit('call-ended', this as unknown as CallInterface)
+    ;(this.wechaty as any).__callPool?.delete(this.id)
+  }
 
   private __transitionTo (nextStatus: CallStatus): void {
     log.verbose('Call', '__transitionTo(%s) from %s', nextStatus, this.__status)
     this.__status = nextStatus
-    if (nextStatus === 'connected' || nextStatus === 'ended') {
-      if (this.__ttlTimer) {
-        clearTimeout(this.__ttlTimer)
-        this.__ttlTimer = undefined
-      }
-    }
-    if (nextStatus === 'ended') {
-      this.__onEnded(this.id)
-    }
   }
 
 }
@@ -302,6 +362,9 @@ interface CallImplInterface extends CallImplBase {}
 
 type CallProtectedProperty =
   | '__handleSignal'
+  | '__markEnded'
+  | '__finalize'
+  | '__endedEmitted'
 
 type CallInterface = Omit<CallImplInterface, CallProtectedProperty>
 class CallImpl extends validationMixin(CallImplBase)<CallInterface>() {}
@@ -318,7 +381,6 @@ export type {
 }
 export {
   CallImpl,
-  randomUUID as generateCallId,
 }
 
 class CallRecordMixin extends wechatifyMixinBase() {

--- a/src/user-modules/call.ts
+++ b/src/user-modules/call.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import * as PUPPET from '@juzi/wechaty-puppet'
 
 import type { Constructor } from 'clone-class'
@@ -6,9 +8,269 @@ import { log } from '../config.js'
 import { validationMixin } from '../user-mixins/validation.js'
 
 import {
+  wechatifyMixin,
   wechatifyMixinBase,
 } from '../user-mixins/wechatify.js'
+import { CallEventEmitter } from '../schemas/call-events.js'
 import type { ContactImpl, ContactInterface } from './contact.js'
+
+/**
+ * Lifecycle status of a call session as seen from this side.
+ *
+ * Intentionally defined here (not in wechaty-puppet) because the puppet's
+ * `CallStatus` enum is already occupied by the call-record domain.
+ */
+export type CallStatus    = 'calling' | 'ringing' | 'connected' | 'ended'
+export type CallDirection = 'outgoing' | 'incoming'
+
+interface CallConstructorOptions {
+  readonly id        : string
+  readonly peerId    : string
+  readonly media     : PUPPET.types.CallMediaType
+  readonly direction : CallDirection
+  /** If omitted the status is derived: outgoing→calling, incoming→ringing */
+  readonly status?   : CallStatus
+  /** Called when the call transitions to ended so the registry can clean up */
+  readonly onEnded   : (callId: string) => void
+}
+
+const CallMixinBase = wechatifyMixin(CallEventEmitter)
+
+/**
+ * Call – a live, stateful call-control session abstraction.
+ *
+ * A Call is a first-class citizen alongside Message and Contact.
+ * It models the signaling lifecycle of a call (not the media connection itself;
+ * media runs peer-to-peer and is associated only by `callId`).
+ *
+ * Outgoing: obtain via `contact.call()`.
+ * Incoming: received as the argument of the `bot.on('call', …)` event.
+ */
+class CallMixin extends CallMixinBase {
+
+  readonly id : string
+
+  private __peerId    : string
+  private __media     : PUPPET.types.CallMediaType
+  private __status    : CallStatus
+  private __direction : CallDirection
+  private __onEnded   : (callId: string) => void
+
+  constructor (options: CallConstructorOptions) {
+    super()
+
+    this.id          = options.id
+    this.__peerId    = options.peerId
+    this.__media     = options.media
+    this.__direction = options.direction
+    this.__onEnded   = options.onEnded
+
+    // Derive initial status from direction when not explicitly provided.
+    if (options.status !== undefined) {
+      this.__status = options.status
+    } else {
+      this.__status = options.direction === 'outgoing' ? 'calling' : 'ringing'
+    }
+
+    log.verbose('Call', 'constructor(%s, dir=%s, media=%s)', this.id, this.__direction, this.__media)
+  }
+
+  /** The remote party: callee when outgoing, caller when incoming. */
+  contact (): ContactInterface {
+    return (this.wechaty.Contact as typeof ContactImpl).load(this.__peerId)
+  }
+
+  media (): PUPPET.types.CallMediaType {
+    return this.__media
+  }
+
+  status (): CallStatus {
+    return this.__status
+  }
+
+  direction (): CallDirection {
+    return this.__direction
+  }
+
+  // ---------------------------------------------------------------------------
+  // Control methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Accept an incoming call.
+   * Only valid when direction=incoming and status=ringing.
+   */
+  async accept (): Promise<void> {
+    if (this.__direction !== 'incoming' || this.__status !== 'ringing') {
+      throw new Error(
+        `Call.accept() invalid: direction=${this.__direction}, status=${this.__status}. `
+        + 'Only valid for incoming calls in ringing state.',
+      )
+    }
+
+    await this.wechaty.puppet.callControl({
+      callId : this.id,
+      signal : PUPPET.types.CallSignal.Accept,
+      peerId : this.__peerId,
+      media  : this.__media,
+    })
+
+    this.__transitionTo('connected')
+  }
+
+  /**
+   * Reject an incoming call.
+   * Only valid when direction=incoming and status=ringing.
+   */
+  async reject (reason?: string): Promise<void> {
+    if (this.__direction !== 'incoming' || this.__status !== 'ringing') {
+      throw new Error(
+        `Call.reject() invalid: direction=${this.__direction}, status=${this.__status}. `
+        + 'Only valid for incoming calls in ringing state.',
+      )
+    }
+
+    await this.wechaty.puppet.callControl({
+      callId : this.id,
+      signal : PUPPET.types.CallSignal.Reject,
+      peerId : this.__peerId,
+      reason,
+    })
+
+    this.__transitionTo('ended')
+  }
+
+  /**
+   * Hang up a connected call.
+   * Only valid when status=connected.
+   */
+  async hangup (reason?: string): Promise<void> {
+    if (this.__status !== 'connected') {
+      throw new Error(
+        `Call.hangup() invalid: status=${this.__status}. `
+        + 'Only valid for connected calls.',
+      )
+    }
+
+    await this.wechaty.puppet.callControl({
+      callId : this.id,
+      signal : PUPPET.types.CallSignal.Hangup,
+      peerId : this.__peerId,
+      reason,
+    })
+
+    this.__transitionTo('ended')
+  }
+
+  /**
+   * Cancel an outgoing call before it is connected.
+   * Only valid when direction=outgoing and status=calling or ringing.
+   */
+  async cancel (): Promise<void> {
+    if (this.__direction !== 'outgoing') {
+      throw new Error(
+        `Call.cancel() invalid: direction=${this.__direction}. `
+        + 'Only valid for outgoing calls.',
+      )
+    }
+    if (this.__status !== 'calling' && this.__status !== 'ringing') {
+      throw new Error(
+        `Call.cancel() invalid: status=${this.__status}. `
+        + 'Only valid when status is calling or ringing.',
+      )
+    }
+
+    await this.wechaty.puppet.callControl({
+      callId : this.id,
+      signal : PUPPET.types.CallSignal.Cancel,
+      peerId : this.__peerId,
+    })
+
+    this.__transitionTo('ended')
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal signal handler – called from puppet-mixin
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Process an inbound call signal from the puppet layer.
+   * This method is framework-internal and must not be called from user code.
+   */
+  __handleSignal (payload: PUPPET.payloads.EventCall): void {
+    if (this.__status === 'ended') {
+      log.warn('Call', '__handleSignal(%s) ignoring signal in ended state', payload.signal)
+      return
+    }
+
+    switch (payload.signal) {
+      case PUPPET.types.CallSignal.Ringing:
+        if (this.__direction === 'outgoing' && this.__status === 'calling') {
+          this.__transitionTo('ringing')
+          this.emit('ringing')
+        }
+        break
+
+      case PUPPET.types.CallSignal.Accept:
+        if (this.__status === 'calling' || this.__status === 'ringing') {
+          this.__transitionTo('connected')
+          this.emit('accept')
+        }
+        break
+
+      case PUPPET.types.CallSignal.Reject:
+        this.__transitionTo('ended')
+        this.emit('reject', payload.reason)
+        break
+
+      case PUPPET.types.CallSignal.Cancel:
+        // The caller cancelled. From the callee's perspective this means the
+        // call ended. Surface as 'hangup' since there is no 'cancel' user event.
+        this.__transitionTo('ended')
+        this.emit('hangup', payload.reason)
+        break
+
+      case PUPPET.types.CallSignal.Hangup:
+        this.__transitionTo('ended')
+        this.emit('hangup', payload.reason)
+        break
+
+      default:
+        log.warn('Call', '__handleSignal() unhandled signal: %s', payload.signal)
+        break
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private __transitionTo (nextStatus: CallStatus): void {
+    log.verbose('Call', '__transitionTo(%s) from %s', nextStatus, this.__status)
+    this.__status = nextStatus
+    if (nextStatus === 'ended') {
+      this.__onEnded(this.id)
+    }
+  }
+
+}
+
+class CallImpl extends validationMixin(CallMixin)<CallInterface>() {}
+interface CallInterface extends CallImpl {}
+
+type CallConstructor = Constructor<
+  CallInterface,
+  typeof CallImpl
+>
+
+export type {
+  CallConstructor,
+  CallInterface,
+}
+export {
+  CallImpl,
+  randomUUID as generateCallId,
+}
 
 class CallRecordMixin extends wechatifyMixinBase() {
 

--- a/src/user-modules/call.ts
+++ b/src/user-modules/call.ts
@@ -297,8 +297,14 @@ class CallMixin extends CallMixinBase {
 
 }
 
-class CallImpl extends validationMixin(CallMixin)<CallInterface>() {}
-interface CallInterface extends CallImpl {}
+class CallImplBase extends validationMixin(CallMixin)<CallImplInterface>() {}
+interface CallImplInterface extends CallImplBase {}
+
+type CallProtectedProperty =
+  | '__handleSignal'
+
+type CallInterface = Omit<CallImplInterface, CallProtectedProperty>
+class CallImpl extends validationMixin(CallImplBase)<CallInterface>() {}
 
 type CallConstructor = Constructor<
   CallInterface,
@@ -308,6 +314,7 @@ type CallConstructor = Constructor<
 export type {
   CallConstructor,
   CallInterface,
+  CallProtectedProperty,
 }
 export {
   CallImpl,

--- a/src/user-modules/contact.ts
+++ b/src/user-modules/contact.ts
@@ -52,8 +52,7 @@ import { stringifyFilter }            from '../helper-functions/stringify-filter
 import type { MessageInterface }  from './message.js'
 import type { TagInterface }      from './tag.js'
 import type { ContactSelfImpl }   from './contact-self.js'
-import type { CallImpl, CallInterface } from './call.js'
-import { generateCallId } from './call.js'
+import type { CallInterface } from './call.js'
 
 const MixinBase = wechatifyMixin(
   poolifyMixin(
@@ -410,50 +409,20 @@ class ContactMixin extends MixinBase implements SayableSayer {
   }
 
   /**
-   * Initiate an outgoing call to this contact.
+   * Initiate an outgoing 1-on-1 call to this contact.
    *
-   * Returns a Call object immediately (status: 'calling') without blocking
-   * until the call is connected. Listen to call events for lifecycle updates.
+   * Syntactic sugar over `bot.call([this], options)`. Returns a Call object
+   * immediately (status: 'calling'); listen to call events for lifecycle updates.
    *
    * @example
    * import * as PUPPET from '@juzi/wechaty-puppet'
    * const call = await contact.call({ media: PUPPET.types.CallMediaType.Video })
-   * call.on('accept', () => console.log('call connected'))
-   * call.on('hangup', reason => console.log('call ended', reason))
+   * call.on('accept', actor => console.log('connected with', actor.name()))
+   * call.on('ended', () => console.log('call ended'))
    */
   async call (options?: { media?: PUPPET.types.CallMediaType }): Promise<CallInterface> {
     log.verbose('Contact', 'call(%s)', JSON.stringify(options ?? {}))
-
-    const callId = generateCallId()
-    const media  = options?.media ?? PUPPET.types.CallMediaType.Audio
-
-    const wechaty = this.wechaty as any
-
-    const call = new (this.wechaty.Call as any)({
-      id        : callId,
-      peerId    : this.id,
-      media,
-      direction : 'outgoing' as const,
-      onEnded   : (id: string) => { wechaty.__callPool?.delete(id) },
-    }) as CallImpl
-
-    // Register before sending Invite to avoid a race where the acknowledgement
-    // arrives before the await returns.
-    wechaty.__callPool?.set(callId, call)
-
-    try {
-      await this.wechaty.puppet.callControl({
-        callId,
-        signal : PUPPET.types.CallSignal.Invite,
-        peerId : this.id,
-        media,
-      })
-    } catch (e) {
-      wechaty.__callPool?.delete(callId)
-      throw e
-    }
-
-    return call as unknown as CallInterface
+    return (this.wechaty as any).call([ this as unknown as ContactInterface ], options)
   }
 
   /**

--- a/src/user-modules/contact.ts
+++ b/src/user-modules/contact.ts
@@ -416,12 +416,13 @@ class ContactMixin extends MixinBase implements SayableSayer {
    * until the call is connected. Listen to call events for lifecycle updates.
    *
    * @example
-   * const call = await contact.call({ media: bot.PUPPET.types.CallMediaType.Video })
+   * import * as PUPPET from '@juzi/wechaty-puppet'
+   * const call = await contact.call({ media: PUPPET.types.CallMediaType.Video })
    * call.on('accept', () => console.log('call connected'))
    * call.on('hangup', reason => console.log('call ended', reason))
    */
   async call (options?: { media?: PUPPET.types.CallMediaType }): Promise<CallInterface> {
-    log.verbose('Contact', 'call(%s)', JSON.stringify(options) || '')
+    log.verbose('Contact', 'call(%s)', JSON.stringify(options ?? {}))
 
     const callId = generateCallId()
     const media  = options?.media ?? PUPPET.types.CallMediaType.Audio

--- a/src/user-modules/contact.ts
+++ b/src/user-modules/contact.ts
@@ -52,6 +52,8 @@ import { stringifyFilter }            from '../helper-functions/stringify-filter
 import type { MessageInterface }  from './message.js'
 import type { TagInterface }      from './tag.js'
 import type { ContactSelfImpl }   from './contact-self.js'
+import type { CallImpl, CallInterface } from './call.js'
+import { generateCallId } from './call.js'
 
 const MixinBase = wechatifyMixin(
   poolifyMixin(
@@ -405,6 +407,52 @@ class ContactMixin extends MixinBase implements SayableSayer {
         return msg
       }
     }
+  }
+
+  /**
+   * Initiate an outgoing call to this contact.
+   *
+   * Returns a Call object immediately (status: 'calling') without blocking
+   * until the call is connected. Listen to call events for lifecycle updates.
+   *
+   * @example
+   * const call = await contact.call({ media: bot.PUPPET.types.CallMediaType.Video })
+   * call.on('accept', () => console.log('call connected'))
+   * call.on('hangup', reason => console.log('call ended', reason))
+   */
+  async call (options?: { media?: PUPPET.types.CallMediaType }): Promise<CallInterface> {
+    log.verbose('Contact', 'call(%s)', JSON.stringify(options) || '')
+
+    const callId = generateCallId()
+    const media  = options?.media ?? PUPPET.types.CallMediaType.Audio
+
+    const wechaty = this.wechaty as any
+
+    const call = new (this.wechaty.Call as any)({
+      id        : callId,
+      peerId    : this.id,
+      media,
+      direction : 'outgoing' as const,
+      onEnded   : (id: string) => { wechaty.__callPool?.delete(id) },
+    }) as CallImpl
+
+    // Register before sending Invite to avoid a race where the acknowledgement
+    // arrives before the await returns.
+    wechaty.__callPool?.set(callId, call)
+
+    try {
+      await this.wechaty.puppet.callControl({
+        callId,
+        signal : PUPPET.types.CallSignal.Invite,
+        peerId : this.id,
+        media,
+      })
+    } catch (e) {
+      wechaty.__callPool?.delete(callId)
+      throw e
+    }
+
+    return call as unknown as CallInterface
   }
 
   /**

--- a/src/user-modules/mod.ts
+++ b/src/user-modules/mod.ts
@@ -123,9 +123,16 @@ import {
   PremiumOnlineAppointmentCardConstructor,
 }                           from './premium-online-appointment-card.js'
 import {
+  CallImpl,
+  CallInterface,
+  CallConstructor,
   CallRecordImpl,
   CallRecordInterface,
   CallRecordConstructor,
+}                           from './call.js'
+export type {
+  CallStatus,
+  CallDirection,
 }                           from './call.js'
 import {
   ChatHistoryImpl,
@@ -161,6 +168,7 @@ import {
 import { wechatifyUserModule } from '../user-mixins/wechatify.js'
 
 export type {
+  CallInterface,
   ContactInterface,
   ContactSelfInterface,
   FavoriteInterface,
@@ -192,6 +200,7 @@ export type {
 }
 
 export type {
+  CallConstructor,
   ContactConstructor,
   ContactSelfConstructor,
   FavoriteConstructor,
@@ -225,6 +234,7 @@ export type {
 export {
   wechatifyUserModule,
 
+  CallImpl,
   ContactImpl,
   ContactSelfImpl,
   FavoriteImpl,

--- a/src/user-modules/mod.ts
+++ b/src/user-modules/mod.ts
@@ -130,10 +130,6 @@ import {
   CallRecordInterface,
   CallRecordConstructor,
 }                           from './call.js'
-export type {
-  CallStatus,
-  CallDirection,
-}                           from './call.js'
 import {
   ChatHistoryImpl,
   ChatHistoryInterface,
@@ -166,6 +162,11 @@ import {
 }                           from './wxxd-order.js'
 
 import { wechatifyUserModule } from '../user-mixins/wechatify.js'
+
+export type {
+  CallStatus,
+  CallDirection,
+}                           from './call.js'
 
 export type {
   CallInterface,

--- a/src/wechaty-mixins/puppet-mixin.ts
+++ b/src/wechaty-mixins/puppet-mixin.ts
@@ -15,6 +15,7 @@ import {
 import { config, PUPPET_PAYLOAD_SYNC_GAP, PUPPET_PAYLOAD_SYNC_MAX_RETRY }               from '../config.js'
 import { timestampToDate }      from '../pure-functions/timestamp-to-date.js'
 import type {
+  CallImpl,
   ContactImpl,
   ContactInterface,
   MessageImpl,
@@ -50,6 +51,9 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
   abstract class PuppetMixin extends mixinBase {
 
     __puppet?: PUPPET.impls.PuppetInterface
+
+    /** Registry of active Call instances keyed by callId. */
+    __callPool: Map<string, CallImpl> = new Map()
 
     get puppet (): PUPPET.impls.PuppetInterface {
       if (!this.__puppet) {
@@ -791,6 +795,33 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
             })
             break
 
+          case 'call':
+            puppet.on('call', async payload => {
+              try {
+                if (payload.signal === PUPPET.types.CallSignal.Invite) {
+                  const call = new (this.Call as any)({
+                    id        : payload.callId,
+                    peerId    : payload.contactId,
+                    media     : payload.media ?? PUPPET.types.CallMediaType.Audio,
+                    direction : 'incoming' as const,
+                    onEnded   : (callId: string) => { this.__callPool.delete(callId) },
+                  }) as CallImpl
+                  this.__callPool.set(call.id, call)
+                  this.emit('call', call as any)
+                } else {
+                  const call = this.__callPool.get(payload.callId)
+                  if (!call) {
+                    this.emit('error', GError.from('call event for unknown callId: ' + payload.callId))
+                    return
+                  }
+                  call.__handleSignal(payload)
+                }
+              } catch (e) {
+                this.emit('error', GError.from(e))
+              }
+            })
+            break
+
           default:
             /**
              * Check: The eventName here should have the type `never`
@@ -812,6 +843,7 @@ type PuppetMixin = ReturnType<typeof puppetMixin>
 
 type ProtectedPropertyPuppetMixin =
   | '__puppet'
+  | '__callPool'
   | '__readyState'
   | '__setupPuppetEvents'
   | '__loginIndicator'

--- a/src/wechaty-mixins/puppet-mixin.ts
+++ b/src/wechaty-mixins/puppet-mixin.ts
@@ -801,6 +801,10 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
             puppet.on('call', async payload => {
               try {
                 if (payload.signal === PUPPET.types.CallSignal.Invite) {
+                  if (this.__callPool.has(payload.callId)) {
+                    log.warn('WechatyPuppetMixin', '__setupPuppetEvents() duplicate Invite for callId=%s, ignoring', payload.callId)
+                    return
+                  }
                   const call = new (this.Call as any)({
                     id        : payload.callId,
                     peerId    : payload.contactId,

--- a/src/wechaty-mixins/puppet-mixin.ts
+++ b/src/wechaty-mixins/puppet-mixin.ts
@@ -152,6 +152,8 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
       log.verbose('WechatyPuppetMixin', 'stop() super.stop() ...')
       await super.stop()
       log.verbose('WechatyPuppetMixin', 'stop() super.stop() ... done')
+
+      this.__callPool.clear()
     }
 
     async ready (): Promise<void> {
@@ -802,7 +804,7 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                   const call = new (this.Call as any)({
                     id        : payload.callId,
                     peerId    : payload.contactId,
-                    media     : payload.media ?? PUPPET.types.CallMediaType.Audio,
+                    media     : payload.media,
                     direction : 'incoming' as const,
                     onEnded   : (callId: string) => { this.__callPool.delete(callId) },
                   }) as CallImpl

--- a/src/wechaty-mixins/puppet-mixin.ts
+++ b/src/wechaty-mixins/puppet-mixin.ts
@@ -751,6 +751,33 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                     await order?.ready(true)
                     break
                   }
+                  case PUPPET.types.Payload.Call: {
+                    /**
+                     * Invalidate the puppet-side cache so the next callPayload()
+                     * pull reflects the latest server state, then refresh the
+                     * user-layer Call payload so getters (media / participants /
+                     * endTime) reflect the new view immediately. Whether the
+                     * call is still alive is still decided by the call-event
+                     * handler via __finalizeIfEnded; we do not touch the pool
+                     * here, and we do not emit a synthetic user event — the
+                     * UI is expected to read getters when it needs the value.
+                     */
+                    await this.puppet.callPayloadDirty(payloadId)
+                    const call = this.__callPool.get(payloadId)
+                    if (call) {
+                      try {
+                        await call.ready(true)
+                      } catch (e) {
+                        log.warn(
+                          'WechatyPuppetMixin',
+                          'dirty(Call) ready failed for callId=%s: %s',
+                          payloadId,
+                          (e as Error).message,
+                        )
+                      }
+                    }
+                    break
+                  }
 
                   case PUPPET.types.Payload.Unspecified:
                   default:
@@ -807,20 +834,55 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                   }
                   const call = new (this.Call as any)({
                     id        : payload.callId,
-                    peerId    : payload.contactId,
-                    media     : payload.media,
                     direction : 'incoming' as const,
-                    onEnded   : (callId: string) => { this.__callPool.delete(callId) },
                   }) as CallImpl
+                  await call.ready()
                   this.__callPool.set(call.id, call)
                   this.emit('call', call as any)
-                } else {
-                  const call = this.__callPool.get(payload.callId)
-                  if (!call) {
-                    this.emit('error', GError.from('call event for unknown callId: ' + payload.callId))
-                    return
-                  }
-                  call.__handleSignal(payload)
+                  return
+                }
+
+                const call = this.__callPool.get(payload.callId)
+                if (!call) {
+                  // Under the protocol-mints-id model, signals for an unknown callId
+                  // are expected within race windows (e.g. a Ringing ack arriving
+                  // before callInvite returns) or after the Call has been finalized
+                  // and removed from the pool. Drop silently — log.warn, not error.
+                  log.warn('WechatyPuppetMixin', '__setupPuppetEvents() call event for unknown callId=%s, dropping', payload.callId)
+                  return
+                }
+
+                const actor = await (this.Contact as typeof ContactImpl).find({ id: payload.contactId })
+                if (!actor) {
+                  log.warn('WechatyPuppetMixin', '__setupPuppetEvents() actor contact not found for callId=%s contactId=%s, dropping', payload.callId, payload.contactId)
+                  return
+                }
+
+                call.__handleSignal(payload.signal, actor, payload.reason)
+
+                switch (payload.signal) {
+                  case PUPPET.types.CallSignal.Ringing:
+                    this.emit('call-ringing', call as any)
+                    break
+                  case PUPPET.types.CallSignal.Accept:
+                    this.emit('call-accept', call as any, actor as any)
+                    break
+                  case PUPPET.types.CallSignal.Reject:
+                    this.emit('call-reject', call as any, actor as any, payload.reason)
+                    await this.__finalizeIfEnded(call)
+                    break
+                  case PUPPET.types.CallSignal.Cancel:
+                    this.emit('call-cancel', call as any, payload.reason)
+                    // Cancel is a peer-side terminal action on the receiving side:
+                    // the caller has withdrawn, so the local call necessarily ends.
+                    await this.__finalizeIfEnded(call, /* force */ true)
+                    break
+                  case PUPPET.types.CallSignal.Hangup:
+                    this.emit('call-hangup', call as any, actor as any, payload.reason)
+                    await this.__finalizeIfEnded(call)
+                    break
+                  default:
+                    break
                 }
               } catch (e) {
                 this.emit('error', GError.from(e))
@@ -840,6 +902,89 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
       log.verbose('WechatyPuppetMixin', '__setupPuppetEvents() ... done')
     }
 
+    /**
+     * Decide whether a call has reached its terminal state and, if so, drive
+     * the local lifecycle to ended by invoking {@link CallImpl.__markEnded},
+     * which routes through __finalize and is responsible for emitting both
+     * the object 'ended' and the bot 'call-ended' lifecycle events as well
+     * as evicting the call from the pool. This method does NOT emit
+     * 'call-ended' directly — that would risk a double-emit if a local
+     * control path (reject/cancel/hangup) finalizes the call before the
+     * puppet echo reaches here. The `__endedEmitted` sentinel inside
+     * __finalize makes the joint behavior idempotent.
+     *
+     * Strategy:
+     *   - `force=true` short-circuits when the caller already knows the call is
+     *     over (Cancel from the receiver's perspective).
+     *   - Otherwise, refresh the payload via dirty + ready and check
+     *     `endTime`, with a short retry budget so transient puppet hiccups do
+     *     not strand a Call in the pool.
+     *   - As a last-resort heuristic, an ended-leaning signal (Reject / Hangup)
+     *     on a strict 1v1 call (participants.length === 2: the starter plus
+     *     exactly one invitee) is treated as terminal even if sync never
+     *     recovered: in 1v1 the protocol has no other peer to keep the
+     *     session alive. Other roster shapes (length 0/1/3+) fall through
+     *     and wait for the next dirty signal — length<=1 is a stranded-but-
+     *     recoverable shape (empty roster from a sync hiccup, or a multi-
+     *     party call whose other members already left).
+     */
+    async __finalizeIfEnded (call: CallImpl, force = false): Promise<void> {
+      let ended = force
+
+      if (!ended) {
+        for (let attempt = 0; attempt < 3 && !ended; attempt++) {
+          try {
+            await call.sync()
+            ended = !!call.endTime()
+          } catch (e) {
+            log.warn(
+              'WechatyPuppetMixin',
+              '__finalizeIfEnded() sync attempt %d failed for callId=%s: %s',
+              attempt + 1,
+              call.id,
+              (e as Error).message,
+            )
+          }
+          if (!ended && attempt < 2) {
+            await new Promise(resolve => setTimeout(resolve, 500))
+          }
+        }
+      }
+
+      if (!ended) {
+        try {
+          const participants = await call.participants()
+          if (participants.length === 2) {
+            log.warn(
+              'WechatyPuppetMixin',
+              '__finalizeIfEnded() 1v1 fallback after sync failure for callId=%s (rosterLength=%d)',
+              call.id,
+              participants.length,
+            )
+            ended = true
+          } else {
+            log.error(
+              'WechatyPuppetMixin',
+              '__finalizeIfEnded() sync failed, leaving callId=%s in pool for next dirty signal (rosterLength=%d)',
+              call.id,
+              participants.length,
+            )
+          }
+        } catch (e) {
+          log.error(
+            'WechatyPuppetMixin',
+            '__finalizeIfEnded() participants lookup failed for callId=%s: %s',
+            call.id,
+            (e as Error).message,
+          )
+        }
+      }
+
+      if (ended) {
+        call.__markEnded()
+      }
+    }
+
   }
 
   return PuppetMixin
@@ -852,6 +997,7 @@ type ProtectedPropertyPuppetMixin =
   | '__callPool'
   | '__readyState'
   | '__setupPuppetEvents'
+  | '__finalizeIfEnded'
   | '__loginIndicator'
 
 export type {

--- a/src/wechaty-mixins/wechatify-user-module-mixin.ts
+++ b/src/wechaty-mixins/wechatify-user-module-mixin.ts
@@ -1,6 +1,7 @@
 import { log }          from '@juzi/wechaty-puppet'
 
 import {
+  CallImpl,
   ContactImpl,
   ContactSelfImpl,
   DelayImpl,
@@ -28,6 +29,7 @@ import {
   WxxdProductImpl,
   WxxdOrderImpl,
 
+  CallConstructor,
   ContactConstructor,
   ContactSelfConstructor,
   DelayConstructor,
@@ -71,6 +73,7 @@ const wechatifyUserModuleMixin = <MixinBase extends typeof WechatySkeleton> (mix
       super(...args)
     }
 
+    __wechatifiedCall?                          : CallConstructor
     __wechatifiedContact?                       : ContactConstructor
     __wechatifiedContactSelf?                   : ContactSelfConstructor
     __wechatifiedDelay?                         : DelayConstructor
@@ -98,6 +101,7 @@ const wechatifyUserModuleMixin = <MixinBase extends typeof WechatySkeleton> (mix
     __wechatifiedWxxdProduct?                   : WxxdProductConstructor
     __wechatifiedWxxdOrder?                     : WxxdOrderConstructor
 
+    get Call ()                         : CallConstructor                           { return guardWechatify(this.__wechatifiedCall)           }
     get Contact ()                      : ContactConstructor                        { return guardWechatify(this.__wechatifiedContact)        }
     get ContactSelf ()                  : ContactSelfConstructor                    { return guardWechatify(this.__wechatifiedContactSelf)    }
     get Delay ()                        : DelayConstructor                          { return guardWechatify(this.__wechatifiedDelay)          }
@@ -145,6 +149,7 @@ const wechatifyUserModuleMixin = <MixinBase extends typeof WechatySkeleton> (mix
        *
        * Huan(202110): FIXME: remove any
        */
+      this.__wechatifiedCall                         = wechatifyUserModule(CallImpl)(this as any)
       this.__wechatifiedContact                      = wechatifyUserModule(ContactImpl)(this as any)
       this.__wechatifiedContactSelf                  = wechatifyUserModule(ContactSelfImpl)(this as any)
       this.__wechatifiedDelay                        = wechatifyUserModule(DelayImpl)(this as any)
@@ -193,6 +198,7 @@ function guardWechatify<T extends Function> (userModule?: T): T {
 type WechatifyUserModuleMixin = ReturnType<typeof wechatifyUserModuleMixin>
 
 type ProtectedPropertyWechatifyUserModuleMixin =
+  | '__wechatifiedCall'
   | '__wechatifiedContact'
   | '__wechatifiedContactSelf'
   | '__wechatifiedDelay'

--- a/src/wechaty/wechaty-base.ts
+++ b/src/wechaty/wechaty-base.ts
@@ -52,7 +52,9 @@ import type {
 import type {
   WechatyOptions,
 }                             from '../schemas/wechaty-options.js'
-import type { PostInterface } from '../user-modules/post.js'
+import type { PostInterface }            from '../user-modules/post.js'
+import type { CallImpl, CallInterface }  from '../user-modules/call.js'
+import type { ContactInterface }         from '../user-modules/contact.js'
 
 const mixinBase = FP.pipe(
   WechatySkeleton,
@@ -273,6 +275,43 @@ class WechatyBase extends mixinBase implements SayableSayer {
   ): Promise<void> {
     log.verbose('Wechaty', 'say(%s)', sayable)
     await this.currentUser.say(sayable)
+  }
+
+  /**
+   * Initiate an outgoing call to one or more contacts.
+   *
+   * Mints a protocol-side callId via `puppet.callInvite`, hydrates the Call
+   * payload, and registers the Call in the in-process pool. Returns immediately
+   * (status: 'calling'); listen to call events for lifecycle updates.
+   *
+   * @example
+   * import * as PUPPET from '@juzi/wechaty-puppet'
+   * const call = await bot.call([contactA, contactB], { media: PUPPET.types.CallMediaType.Video })
+   * call.on('accept', actor => console.log('accepted by', actor.name()))
+   * call.on('ended',  () => console.log('call session ended'))
+   */
+  async call (
+    contacts: ContactInterface[],
+    options?: { media?: PUPPET.types.CallMediaType },
+  ): Promise<CallInterface> {
+    log.verbose('Wechaty', 'call(%d contacts, %s)', contacts.length, JSON.stringify(options ?? {}))
+
+    if (contacts.length === 0) {
+      throw new Error('Wechaty.call() requires at least one contact')
+    }
+
+    const media  = options?.media ?? PUPPET.types.CallMediaType.Audio
+    const callId = await this.puppet.callInvite(contacts.map(c => c.id), media)
+
+    const call = new (this.Call as any)({
+      id        : callId,
+      direction : 'outgoing' as const,
+    }) as CallImpl
+
+    await call.ready()
+    ;(this as any).__callPool.set(callId, call)
+
+    return call as unknown as CallInterface
   }
 
   async publish (

--- a/src/wechaty/wechaty-impl.spec.ts
+++ b/src/wechaty/wechaty-impl.spec.ts
@@ -25,6 +25,7 @@ import type {
   ConsultCardConstructor,
   PremiumOnlineAppointmentCardConstructor,
   MomentConstructor,
+  CallConstructor,
   CallRecordConstructor,
   ChatHistoryConstructor,
   WecomConstructor,
@@ -64,6 +65,7 @@ test('Wechaty interface', async t => {
     ConsultCard                   : ConsultCardConstructor
     PremiumOnlineAppointmentCard  : PremiumOnlineAppointmentCardConstructor
     Moment                        : MomentConstructor
+    Call                          : CallConstructor
     CallRecord                    : CallRecordConstructor
     ChatHistory                   : ChatHistoryConstructor
     Wecom                         : WecomConstructor
@@ -94,6 +96,7 @@ test('Wechaty interface', async t => {
         = this.ConsultCard
         = this.PremiumOnlineAppointmentCard
         = this.Moment
+        = this.Call
         = this.CallRecord
         = this.ChatHistory
         = this.Wecom

--- a/src/wechaty/wechaty-impl.spec.ts
+++ b/src/wechaty/wechaty-impl.spec.ts
@@ -123,6 +123,7 @@ test('Wechaty interface', async t => {
     abstract ready           : WechatyInterface['ready']
     abstract reset           : WechatyInterface['reset']
     abstract say             : WechatyInterface['say']
+    abstract call            : WechatyInterface['call']
     abstract sleep           : WechatyInterface['sleep']
     abstract start           : WechatyInterface['start']
     abstract state           : WechatyInterface['state']


### PR DESCRIPTION
## 概述

为 wechaty 用户层落地通话信令域（1.0.148），对齐 [@juzi/wechaty-puppet@1.0.138](https://github.com/juzibot/wechaty-puppet/pull/93) 与 [@juzi/wechaty-puppet-service@1.0.115](https://github.com/juzibot/wechaty-puppet-service/pull/89)。本仓库是契约链的终点；至此 puppet/grpc/service/wechaty 四层 call 域全部到位。

设计稿见 \`docs/wechaty-call-api-design.md\` v2。3 轮 cto-loop 自查（详见下方）。

## 用户层 API 全景

### 发起入口

| 用法 | 形态 |
|---|---|
| 1v1 | \`await contact.call({ media })\`（语法糖） |
| 群通话 | \`await bot.call([B, C, D], { media })\`（统一入口） |

两者立即返回已水合的 \`Call\` 对象（不阻塞等接通），callId 由协议端铸造。\`contact.call\` 内部委托 \`bot.call([this], options)\`。

### Call 对象

```ts
// 字段（payload-hydrated）
call.id                      // string
call.direction()             // 'outgoing' | 'incoming'
call.status()                // 'calling' | 'ringing' | 'connected' | 'ended'（本地状态机）
call.media()                 // CallMediaType
call.startTime()             // Date
call.endTime()               // Date | undefined
await call.starter()         // Contact | undefined（协议端不可知时 undefined）
await call.participants()    // Contact[]

// 控制
await call.accept() / reject(reason?) / cancel() / hangup(reason?)
await call.add(contacts[])               // 中途拉人
await call.mediaEndpoint()               // 媒体入场券（纯透传，按需 pull）
await call.sync()                        // 强制刷新 payload
```

### Bot 层事件（双层，含 \`call\` 实例）

\`bot.on('call', call => ...)\` — 来电（水合后 emit）
\`bot.on('call-ringing', call => ...)\` — 主叫：对端响铃
\`bot.on('call-accept', (call, actor) => ...)\`
\`bot.on('call-reject', (call, actor, reason?) => ...)\`
\`bot.on('call-cancel', (call, reason?) => ...)\`
\`bot.on('call-hangup', (call, actor, reason?) => ...)\`
\`bot.on('call-ended', call => ...)\` — 整通结束（lifecycle 终态，无论本地远端发起都 emit）

### Call 对象事件（不重复实例）

\`call.on('ringing' / 'accept' / 'reject' / 'cancel' / 'hangup' / 'ended', ...)\`

## 关键实现要点

1. **A 模式水合**：入站 invite 事件先 \`await Call.find\`（内部 \`callPayload\`）→ 入池 → \`emit('call', call)\`，对齐 Message.find 既有惯例。用户拿到对象时字段同步可用。
2. **出站时序倒转**：\`await puppet.callInvite(ids, media)\` 拿 callId → new Call → \`await call.ready()\` → 入 \`__callPool\`。先发 RPC 后 new，无需先注册。
3. **终态单点收口**：\`Call.__finalize\` 是 'ended' / 'call-ended' 唯一 emit 来源，\`__endedEmitted\` 哨兵保证幂等。所有路径（本地控制 finally / puppet-mixin \`__markEnded\` / \`__handleSignal(Cancel)\`）都汇入此处。Bot 层 'call-ended' 由 \`__finalize\` 内 \`(this.wechaty).emit\` 一并发出。
4. **终态判定**：\`__finalizeIfEnded\` 3 次重试 \`call.sync()\`，耗尽后用 \`participants.length === 2\` 启发式兜底 1v1（严格双端 roster）；多方场景 log.error 留 pool 等下次 dirty 触发重试。
5. **Cancel 竞态消除**：\`__handleSignal\` Cancel 分支「先 \`__finalize\` 后 \`emit('cancel')\`」，cancel handler 同步运行时 \`status === 'ended'\`，关闭了 handler 内调 \`accept()\` 通过守卫的窗口。
6. **dirty(Call) 隐形**：仅 invalidate puppet cache + 刷新用户层 \`__payload\`，不 emit 用户事件（对齐 contact 改名、room 改 topic 的传统）。媒体切换 / 名册变化 → 下次 getter 自动新值。
7. **删除清单**：60s TTL 兜底（\`CALL_RINGING_TTL_MS\` / \`__ttlTimer\`）、\`generateCallId\`（callId 由协议端铸造）、\`peerId\` 字段（1v1 假设，被 participants 取代）、\`'error'\` 事件（终态走 endTime dirty 信号即可）。

## 测试与自查

- \`npm run build\` / \`lint:es\` / \`lint:ts\` / \`test:unit\` 全绿
- \`call.spec.ts\` 21 子测试覆盖：出站 1v1 / 群通话、入站水合、四种终结路径（本地控制 / 远端 Reject / 远端 Cancel / 远端 Hangup）、状态守卫、池清理、双层事件 exactly-once、dirty(Call) 刷新 payload、bot.call vs contact.call 委托
- 3 轮 cto-loop：
  - 第 1 轮：4 HIGH（本地控制不出池+不 emit 对象 'ended' / sync 失败孤儿 / dirty 不刷用户 payload / EventCall 残留检查）+ 5 MEDIUM
  - 第 2 轮：1 HIGH（call-ended 对称性）+ 3 MEDIUM 已修
  - 第 3 轮：zero CRITICAL/HIGH/MEDIUM 必修，剩余 2 MEDIUM cto 评为「optional gate / follow-up」；带上一段 Reject/Hangup vs Cancel emit 顺序的注释后 PASS