### PR TITLE
fix: narrow Voice fallback to unsupported-only + bump puppet deps (1.0.155)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.154",
+  "version": "1.0.155",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {
@@ -126,8 +126,7 @@
     "state-switch": "^1.7.1",
     "uuid": "^8.3.2",
     "wechaty-token": "^1.1.1",
-    "ws": "^8.5.0",
-    "@juzi/wechaty-puppet": "^1.0.143"
+    "ws": "^8.5.0"
   },
   "devDependencies": {
     "@chatie/eslint-config": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.152",
+  "version": "1.0.153",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {
@@ -109,7 +109,7 @@
   },
   "homepage": "https://github.com/wechaty/",
   "dependencies": {
-    "@juzi/wechaty-puppet-service": "1.0.118",
+    "@juzi/wechaty-puppet-service": "1.0.119",
     "clone-class": "^1.1.1",
     "cmd-ts": "^0.10.0",
     "cockatiel": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.151",
+  "version": "1.0.152",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {
@@ -126,13 +126,14 @@
     "state-switch": "^1.7.1",
     "uuid": "^8.3.2",
     "wechaty-token": "^1.1.1",
-    "ws": "^8.5.0"
+    "ws": "^8.5.0",
+    "@juzi/wechaty-puppet": "^1.0.143"
   },
   "devDependencies": {
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.142",
+    "@juzi/wechaty-puppet": "^1.0.143",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.44",
     "@swc/helpers": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.150",
+  "version": "1.0.151",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.153",
+  "version": "1.0.154",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/src/user-modules/voice.spec.ts
+++ b/src/user-modules/voice.spec.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/**
+ *   Wechaty Chatbot SDK - https://github.com/wechaty/wechaty
+ *
+ *   @copyright 2016 Huan LI (李卓桓) <https://github.com/huan>, and
+ *                   Wechaty Contributors <https://github.com/wechaty>.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+import {
+  test,
+  sinon,
+}             from 'tstest'
+
+import { FileBox }        from 'file-box'
+import type * as PUPPET   from '@juzi/wechaty-puppet'
+import { PuppetMock }     from '@juzi/wechaty-puppet-mock'
+import { WechatyBuilder } from '../wechaty-builder.js'
+
+const MESSAGE_ID = 'message-id-voice'
+
+/**
+ * The fallback must trigger ONLY when the puppet does not implement the new
+ * RPC, never on transient failures: otherwise `text()` silently drops the
+ * `noSpeech` discriminator and makes the bot re-run its own paid ASR.
+ *
+ * The puppet is built & started once and reused across cases (`wechaty.Voice`
+ * is unavailable before `start()`). `messageVoice` / `messageVoiceText` are
+ * assigned directly (rather than via `sinon.stub(puppet, ...)`) because the
+ * installed wechaty-puppet-mock predates those methods, so stubbing a
+ * non-existent property would throw.
+ */
+const puppet  = new PuppetMock() as any
+const wechaty = WechatyBuilder.build({ puppet })
+
+let started = false
+async function ensureStarted () {
+  if (!started) {
+    await wechaty.start()
+    started = true
+  }
+}
+
+const voice = () => wechaty.Voice.create(MESSAGE_ID)
+
+const UNSUPPORTED = new Error('Wechaty Puppet Unsupported API Error.')
+
+test('Voice.file() returns the dedicated messageVoice result when supported', async t => {
+  await ensureStarted()
+  puppet.messageVoice = sinon.stub().resolves(FileBox.fromBuffer(Buffer.from('voice'), 'voice.silk'))
+  puppet.messageFile  = sinon.stub().resolves(FileBox.fromBuffer(Buffer.from('file'), 'file.bin'))
+
+  const fileBox = await voice().file()
+  t.equal(fileBox.name, 'voice.silk', 'should return the messageVoice FileBox')
+  t.ok(puppet.messageVoice.calledOnceWith(MESSAGE_ID), 'should call messageVoice')
+  t.notOk(puppet.messageFile.called, 'should NOT fall back to messageFile when supported')
+})
+
+test('Voice.file() falls back to messageFile on unsupported error', async t => {
+  await ensureStarted()
+  puppet.messageVoice = sinon.stub().rejects(UNSUPPORTED)
+  puppet.messageFile  = sinon.stub().resolves(FileBox.fromBuffer(Buffer.from('file'), 'file.bin'))
+
+  const fileBox = await voice().file()
+  t.equal(fileBox.name, 'file.bin', 'should fall back to messageFile')
+  t.ok(puppet.messageFile.calledOnceWith(MESSAGE_ID), 'should call messageFile on fallback')
+})
+
+test('Voice.file() rethrows a transient error instead of falling back', async t => {
+  await ensureStarted()
+  puppet.messageVoice = sinon.stub().rejects(new Error('socket hang up'))
+  puppet.messageFile  = sinon.stub().resolves(FileBox.fromBuffer(Buffer.from('file'), 'file.bin'))
+
+  await t.rejects(() => voice().file(), /socket hang up/, 'should rethrow the transient error')
+  t.notOk(puppet.messageFile.called, 'should NOT fall back on a transient error')
+})
+
+test('Voice.text() returns the dedicated messageVoiceText payload when supported', async t => {
+  await ensureStarted()
+  puppet.messageVoiceText = sinon.stub().resolves({ text: 'hello', noSpeech: false })
+  puppet.messagePayload   = sinon.stub().resolves({ text: 'legacy' } as PUPPET.payloads.Message)
+
+  const result = await voice().text()
+  t.same(result, { text: 'hello', noSpeech: false }, 'should return the messageVoiceText payload')
+  t.ok(puppet.messageVoiceText.calledOnceWith(MESSAGE_ID), 'should call messageVoiceText')
+  t.notOk(puppet.messagePayload.called, 'should NOT fall back to messagePayload when supported')
+})
+
+test('Voice.text() preserves noSpeech=true from the puppet (skip paid ASR)', async t => {
+  await ensureStarted()
+  puppet.messageVoiceText = sinon.stub().resolves({ text: '', noSpeech: true })
+  puppet.messagePayload   = sinon.stub().resolves({ text: '' } as PUPPET.payloads.Message)
+
+  const result = await voice().text()
+  t.equal(result.noSpeech, true, 'should preserve noSpeech=true so the bot can skip its own ASR')
+  t.notOk(puppet.messagePayload.called, 'should NOT fall back when supported')
+})
+
+test('Voice.text() falls back to messagePayload().text on unsupported error', async t => {
+  await ensureStarted()
+  puppet.messageVoiceText = sinon.stub().rejects(UNSUPPORTED)
+  puppet.messagePayload   = sinon.stub().resolves({ text: 'legacy asr' } as PUPPET.payloads.Message)
+
+  const result = await voice().text()
+  t.same(result, { text: 'legacy asr', noSpeech: false }, 'should fall back to legacy payload.text with noSpeech=false')
+  t.ok(puppet.messagePayload.calledOnceWith(MESSAGE_ID), 'should call messagePayload on fallback')
+})
+
+test('Voice.text() falls back on gRPC UNIMPLEMENTED (code 12)', async t => {
+  await ensureStarted()
+  const unimplemented = Object.assign(new Error('12 UNIMPLEMENTED'), { code: 12 })
+  puppet.messageVoiceText = sinon.stub().rejects(unimplemented)
+  puppet.messagePayload   = sinon.stub().resolves({ text: 'legacy asr' } as PUPPET.payloads.Message)
+
+  const result = await voice().text()
+  t.same(result, { text: 'legacy asr', noSpeech: false }, 'should fall back when the server returns UNIMPLEMENTED')
+  t.ok(puppet.messagePayload.calledOnceWith(MESSAGE_ID), 'should call messagePayload on fallback')
+})
+
+test('Voice.text() rethrows a transient error instead of falling back', async t => {
+  await ensureStarted()
+  puppet.messageVoiceText = sinon.stub().rejects(new Error('ETIMEDOUT'))
+  puppet.messagePayload   = sinon.stub().resolves({ text: 'legacy asr' } as PUPPET.payloads.Message)
+
+  await t.rejects(() => voice().text(), /ETIMEDOUT/, 'should rethrow the transient error')
+  t.notOk(puppet.messagePayload.called, 'should NOT fall back on a transient error (would drop noSpeech)')
+})
+
+test('teardown: stop the shared wechaty', async t => {
+  await wechaty.stop()
+  t.pass('stopped')
+})

--- a/src/user-modules/voice.spec.ts
+++ b/src/user-modules/voice.spec.ts
@@ -77,6 +77,16 @@ test('Voice.file() falls back to messageFile on unsupported error', async t => {
   t.ok(puppet.messageFile.calledOnceWith(MESSAGE_ID), 'should call messageFile on fallback')
 })
 
+test('Voice.file() falls back to messageFile when messageVoice is absent (old puppet)', async t => {
+  await ensureStarted()
+  puppet.messageVoice = undefined // old puppet built without the method at all
+  puppet.messageFile  = sinon.stub().resolves(FileBox.fromBuffer(Buffer.from('file'), 'file.bin'))
+
+  const fileBox = await voice().file()
+  t.equal(fileBox.name, 'file.bin', 'should fall back to messageFile via the typeof guard')
+  t.ok(puppet.messageFile.calledOnceWith(MESSAGE_ID), 'should call messageFile on fallback')
+})
+
 test('Voice.file() rethrows a transient error instead of falling back', async t => {
   await ensureStarted()
   puppet.messageVoice = sinon.stub().rejects(new Error('socket hang up'))
@@ -84,6 +94,17 @@ test('Voice.file() rethrows a transient error instead of falling back', async t 
 
   await t.rejects(() => voice().file(), /socket hang up/, 'should rethrow the transient error')
   t.notOk(puppet.messageFile.called, 'should NOT fall back on a transient error')
+})
+
+test('Voice.file() rethrows a genuine "is not a function" TypeError from a working messageVoice', async t => {
+  await ensureStarted()
+  // method exists but its implementation throws internally — must NOT be
+  // misclassified as unsupported just because the message says "is not a function"
+  puppet.messageVoice = sinon.stub().rejects(new TypeError('innerHelper.process is not a function'))
+  puppet.messageFile  = sinon.stub().resolves(FileBox.fromBuffer(Buffer.from('file'), 'file.bin'))
+
+  await t.rejects(() => voice().file(), /is not a function/, 'should rethrow the internal TypeError')
+  t.notOk(puppet.messageFile.called, 'should NOT mask a real implementation bug')
 })
 
 test('Voice.text() returns the dedicated messageVoiceText payload when supported', async t => {
@@ -103,7 +124,9 @@ test('Voice.text() preserves noSpeech=true from the puppet (skip paid ASR)', asy
   puppet.messagePayload   = sinon.stub().resolves({ text: '' } as PUPPET.payloads.Message)
 
   const result = await voice().text()
+  t.same(result, { text: '', noSpeech: true }, 'should return the puppet payload verbatim')
   t.equal(result.noSpeech, true, 'should preserve noSpeech=true so the bot can skip its own ASR')
+  t.ok(puppet.messageVoiceText.calledOnceWith(MESSAGE_ID), 'should call messageVoiceText')
   t.notOk(puppet.messagePayload.called, 'should NOT fall back when supported')
 })
 
@@ -128,6 +151,16 @@ test('Voice.text() falls back on gRPC UNIMPLEMENTED (code 12)', async t => {
   t.ok(puppet.messagePayload.calledOnceWith(MESSAGE_ID), 'should call messagePayload on fallback')
 })
 
+test('Voice.text() falls back to messagePayload when messageVoiceText is absent (old puppet)', async t => {
+  await ensureStarted()
+  puppet.messageVoiceText = undefined // old puppet built without the method at all
+  puppet.messagePayload   = sinon.stub().resolves({ text: 'legacy asr' } as PUPPET.payloads.Message)
+
+  const result = await voice().text()
+  t.same(result, { text: 'legacy asr', noSpeech: false }, 'should fall back via the typeof guard with noSpeech=false')
+  t.ok(puppet.messagePayload.calledOnceWith(MESSAGE_ID), 'should call messagePayload on fallback')
+})
+
 test('Voice.text() rethrows a transient error instead of falling back', async t => {
   await ensureStarted()
   puppet.messageVoiceText = sinon.stub().rejects(new Error('ETIMEDOUT'))
@@ -135,6 +168,17 @@ test('Voice.text() rethrows a transient error instead of falling back', async t 
 
   await t.rejects(() => voice().text(), /ETIMEDOUT/, 'should rethrow the transient error')
   t.notOk(puppet.messagePayload.called, 'should NOT fall back on a transient error (would drop noSpeech)')
+})
+
+test('Voice.text() rethrows a genuine "is not a function" TypeError from a working messageVoiceText', async t => {
+  await ensureStarted()
+  // regression: a real internal TypeError must NOT be downgraded — that would
+  // drop noSpeech and make the bot re-run its own paid ASR
+  puppet.messageVoiceText = sinon.stub().rejects(new TypeError('innerHelper.process is not a function'))
+  puppet.messagePayload   = sinon.stub().resolves({ text: 'legacy asr' } as PUPPET.payloads.Message)
+
+  await t.rejects(() => voice().text(), /is not a function/, 'should rethrow the internal TypeError')
+  t.notOk(puppet.messagePayload.called, 'should NOT mask a real implementation bug')
 })
 
 test('teardown: stop the shared wechaty', async t => {

--- a/src/user-modules/voice.ts
+++ b/src/user-modules/voice.ts
@@ -43,6 +43,11 @@ const GRPC_STATUS_UNIMPLEMENTED = 12
  * NOT match here: otherwise the fallback silently masks real failures and — for
  * `text()` — discards the `noSpeech` discriminator, making the bot re-run its
  * own paid ASR on voices the puppet already confirmed as empty.
+ *
+ * Note: the "method does not exist at all" case (an old puppet built against a
+ * wechaty-puppet without the method) is detected up-front via a `typeof` guard
+ * at the call site, NOT here — matching the `'is not a function'` text would
+ * also swallow a genuine `TypeError` raised inside a working implementation.
  */
 function isUnsupportedError (e: unknown): boolean {
   const err = e as { code?: number | string; message?: string } | undefined
@@ -50,16 +55,8 @@ function isUnsupportedError (e: unknown): boolean {
   if (err?.code === GRPC_STATUS_UNIMPLEMENTED) {
     return true
   }
-  const message = err?.message || ''
   // puppet implements the abstract method via throwUnsupportedError()
-  if (message.includes('Unsupported API')) {
-    return true
-  }
-  // puppet built against an old wechaty-puppet without the method at all
-  if (message.includes('is not a function')) {
-    return true
-  }
-  return false
+  return (err?.message || '').includes('Unsupported API')
 }
 
 class VoiceMixin extends wechatifyMixinBase() {
@@ -82,20 +79,28 @@ class VoiceMixin extends wechatifyMixinBase() {
    * Get the voice file (FileBox) via the puppet's dedicated `messageVoice` RPC.
    *
    * Falls back to the generic `messageFile` when the puppet does not implement
-   * `messageVoice` (old puppet without the new RPC → rejection), keeping the
-   * behaviour compatible with the legacy "voice file via messageFile" path.
+   * `messageVoice` — either the method is absent (old puppet built without it,
+   * caught by the `typeof` guard) or it rejects with an unsupported-API error.
+   * Keeps the behaviour compatible with the legacy "voice file via messageFile"
+   * path. A genuine runtime error from a working `messageVoice` is rethrown.
    */
   async file (): Promise<FileBoxInterface> {
     log.verbose('Voice', 'file() for id: "%s"', this.id)
+    const puppet = this.wechaty.puppet
+    // puppet built against an old wechaty-puppet without the method at all
+    if (typeof (puppet as { messageVoice?: unknown }).messageVoice !== 'function') {
+      log.verbose('Voice', 'file() messageVoice() absent, fallback to messageFile()')
+      return puppet.messageFile(this.id)
+    }
     try {
-      const fileBox = await this.wechaty.puppet.messageVoice(this.id)
+      const fileBox = await puppet.messageVoice(this.id)
       return fileBox
     } catch (e) {
       if (!isUnsupportedError(e)) {
         throw e
       }
       log.verbose('Voice', 'file() messageVoice() unsupported, fallback to messageFile(): %s', (e as Error).message)
-      const fileBox = await this.wechaty.puppet.messageFile(this.id)
+      const fileBox = await puppet.messageFile(this.id)
       return fileBox
     }
   }
@@ -106,21 +111,31 @@ class VoiceMixin extends wechatifyMixinBase() {
    * "confirmed no speech" (`noSpeech=true`) from "normal transcription".
    *
    * Falls back to reading the legacy `messagePayload().text` when the puppet
-   * does not implement `messageVoiceText` (old puppet without the new RPC →
-   * rejection). Old puppets put the ASR result into `payload.text`, so this
-   * keeps the behaviour compatible; `noSpeech` is `false` in the fallback.
+   * does not implement `messageVoiceText` — either the method is absent (old
+   * puppet built without it, caught by the `typeof` guard) or it rejects with
+   * an unsupported-API error. Old puppets put the ASR result into
+   * `payload.text`, so this keeps the behaviour compatible; `noSpeech` is
+   * `false` in the fallback. A genuine runtime error is rethrown (so the bot
+   * does not silently drop `noSpeech` and re-run its own paid ASR).
    */
   async text (): Promise<PUPPET.payloads.VoiceText> {
     log.verbose('Voice', 'text() for id: "%s"', this.id)
+    const puppet = this.wechaty.puppet
+    // puppet built against an old wechaty-puppet without the method at all
+    if (typeof (puppet as { messageVoiceText?: unknown }).messageVoiceText !== 'function') {
+      log.verbose('Voice', 'text() messageVoiceText() absent, fallback to messagePayload().text')
+      const payload = await puppet.messagePayload(this.id)
+      return { text: payload.text || '', noSpeech: false }
+    }
     try {
-      const payload = await this.wechaty.puppet.messageVoiceText(this.id)
+      const payload = await puppet.messageVoiceText(this.id)
       return payload
     } catch (e) {
       if (!isUnsupportedError(e)) {
         throw e
       }
       log.verbose('Voice', 'text() messageVoiceText() unsupported, fallback to messagePayload().text: %s', (e as Error).message)
-      const payload = await this.wechaty.puppet.messagePayload(this.id)
+      const payload = await puppet.messagePayload(this.id)
       return { text: payload.text || '', noSpeech: false }
     }
   }

--- a/src/user-modules/voice.ts
+++ b/src/user-modules/voice.ts
@@ -62,13 +62,6 @@ function isUnsupportedError (e: unknown): boolean {
   return false
 }
 
-/**
- * Sourced from the puppet method signature (single source of truth) rather than
- * re-declared, since `@juzi/wechaty-puppet` does not re-export `VoiceTextPayload`
- * through its public `payloads` barrel.
- */
-type VoiceTextPayload = Awaited<ReturnType<PUPPET.impls.PuppetInterface['messageVoiceText']>>
-
 class VoiceMixin extends wechatifyMixinBase() {
 
   static create (id: string): VoiceInterface {
@@ -117,7 +110,7 @@ class VoiceMixin extends wechatifyMixinBase() {
    * rejection). Old puppets put the ASR result into `payload.text`, so this
    * keeps the behaviour compatible; `noSpeech` is `false` in the fallback.
    */
-  async text (): Promise<VoiceTextPayload> {
+  async text (): Promise<PUPPET.payloads.VoiceText> {
     log.verbose('Voice', 'text() for id: "%s"', this.id)
     try {
       const payload = await this.wechaty.puppet.messageVoiceText(this.id)

--- a/src/user-modules/voice.ts
+++ b/src/user-modules/voice.ts
@@ -21,12 +21,53 @@ import type {
   FileBoxInterface,
 }                   from 'file-box'
 import type { Constructor } from 'clone-class'
+import type * as PUPPET from '@juzi/wechaty-puppet'
 import { validationMixin } from '../user-mixins/validation.js'
 import { log } from '../config.js'
 
 import {
   wechatifyMixinBase,
 }                       from '../user-mixins/wechatify.js'
+
+/**
+ * gRPC status code for an RPC the server does not implement.
+ * @see https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+ */
+const GRPC_STATUS_UNIMPLEMENTED = 12
+
+/**
+ * Whether `e` means the puppet / server does not implement the new voice RPC,
+ * i.e. it is safe to fall back to the legacy path.
+ *
+ * Transient errors (network / timeout / file expired / other gRPC codes) must
+ * NOT match here: otherwise the fallback silently masks real failures and — for
+ * `text()` — discards the `noSpeech` discriminator, making the bot re-run its
+ * own paid ASR on voices the puppet already confirmed as empty.
+ */
+function isUnsupportedError (e: unknown): boolean {
+  const err = e as { code?: number | string; message?: string } | undefined
+  // old wechaty-puppet-service server without the new RPC → gRPC UNIMPLEMENTED
+  if (err?.code === GRPC_STATUS_UNIMPLEMENTED) {
+    return true
+  }
+  const message = err?.message || ''
+  // puppet implements the abstract method via throwUnsupportedError()
+  if (message.includes('Unsupported API')) {
+    return true
+  }
+  // puppet built against an old wechaty-puppet without the method at all
+  if (message.includes('is not a function')) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Sourced from the puppet method signature (single source of truth) rather than
+ * re-declared, since `@juzi/wechaty-puppet` does not re-export `VoiceTextPayload`
+ * through its public `payloads` barrel.
+ */
+type VoiceTextPayload = Awaited<ReturnType<PUPPET.impls.PuppetInterface['messageVoiceText']>>
 
 class VoiceMixin extends wechatifyMixinBase() {
 
@@ -57,7 +98,10 @@ class VoiceMixin extends wechatifyMixinBase() {
       const fileBox = await this.wechaty.puppet.messageVoice(this.id)
       return fileBox
     } catch (e) {
-      log.verbose('Voice', 'file() messageVoice() failed, fallback to messageFile(): %s', (e as Error).message)
+      if (!isUnsupportedError(e)) {
+        throw e
+      }
+      log.verbose('Voice', 'file() messageVoice() unsupported, fallback to messageFile(): %s', (e as Error).message)
       const fileBox = await this.wechaty.puppet.messageFile(this.id)
       return fileBox
     }
@@ -73,13 +117,16 @@ class VoiceMixin extends wechatifyMixinBase() {
    * rejection). Old puppets put the ASR result into `payload.text`, so this
    * keeps the behaviour compatible; `noSpeech` is `false` in the fallback.
    */
-  async text (): Promise<{ text: string; noSpeech: boolean }> {
+  async text (): Promise<VoiceTextPayload> {
     log.verbose('Voice', 'text() for id: "%s"', this.id)
     try {
       const payload = await this.wechaty.puppet.messageVoiceText(this.id)
       return payload
     } catch (e) {
-      log.verbose('Voice', 'text() messageVoiceText() failed, fallback to messagePayload().text: %s', (e as Error).message)
+      if (!isUnsupportedError(e)) {
+        throw e
+      }
+      log.verbose('Voice', 'text() messageVoiceText() unsupported, fallback to messagePayload().text: %s', (e as Error).message)
       const payload = await this.wechaty.puppet.messagePayload(this.id)
       return { text: payload.text || '', noSpeech: false }
     }


### PR DESCRIPTION
## What

Follow-up to PR #114 review (Minor m1 + Nit N1), plus dependency alignment.

`Voice.file()` / `Voice.text()` caught every error and silently fell back to the legacy path. On a new puppet a transient failure (network / timeout / file expired / non-UNIMPLEMENTED gRPC) would wrongly downgrade — and for `text()` that discards the `noSpeech` discriminator, making the bot re-run its own paid ASR on voices the puppet already confirmed empty, defeating the cost optimization this feature exists for.

## Changes

- m1 — fall back only when the puppet/server genuinely lacks the RPC:
  - method absent (old puppet built without it) → detected up-front by a `typeof` guard, not by matching `"is not a function"` (which would also swallow a genuine TypeError from a working implementation)
  - gRPC UNIMPLEMENTED (code 12) → old puppet-service server
  - `"Unsupported API"` message → puppet's `throwUnsupportedError()`
  - every other error is rethrown
- N1 — `text()` returns the public `PUPPET.payloads.VoiceText` type (single source of truth, via juzibot/wechaty-puppet#98).
- Tests — new `src/user-modules/voice.spec.ts`: supported / unsupported-fallback / absent-method / transient-rethrow / genuine-TypeError-rethrow / gRPC code-12 / noSpeech preservation for both accessors.
- Deps — `@juzi/wechaty-puppet` `^1.0.142 → ^1.0.143` (devDependencies); `@juzi/wechaty-puppet-service` `1.0.118 → 1.0.119`.
- Version `1.0.150 → 1.0.155`.

## Verification

- `npm run build` (tsc + tsc cjs): PASS
- `eslint voice.ts voice.spec.ts`: PASS
- `tap voice.spec.ts`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)