### PR TITLE
fix: drop dirty(Call) self-loop & make alias() poll bypass stale LRU

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.155",
+  "version": "1.0.156",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -922,7 +922,11 @@ test('dirty(Call) refreshes user-layer payload so getters see new value', async 
   await flush()
 
   t.equal(incoming!.media(), PUPPET.types.CallMediaType.Video, 'media should reflect refreshed payload after dirty')
-  t.ok((puppet.callPayloadDirty as any).called, 'puppet.callPayloadDirty should be invoked')
+  // Note: the handler intentionally does NOT call puppet.callPayloadDirty;
+  // doing so would form a gRPC loop under puppet-service (server bounces the
+  // dirty back through the event stream). Cache invalidation is handled by
+  // the cache-mixin onDirty listener; the user-visible contract is that
+  // .media() above reflects the fresh server value.
 
   await wechaty.stop()
   sandbox.restore()

--- a/src/user-modules/contact-alias-polling.spec.ts
+++ b/src/user-modules/contact-alias-polling.spec.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+
+import { test }       from 'tstest'
+import { PuppetMock } from '@juzi/wechaty-puppet-mock'
+
+import { WechatyBuilder } from '../wechaty-builder.js'
+
+/**
+ * Regression: `Contact.alias(newAlias)` invokes
+ *   1. puppet.contactAlias(id, newAlias)    // gRPC write
+ *   2. puppet.contactPayloadDirty(id)       // ONCE, outside the loop  ← BUG
+ *   3. loop 10× { sleep 300ms; puppet.contactPayload(id); check }
+ *
+ * Under puppet-service the first contactPayload() call after a dirty
+ * clears both the LRU and the FlashStore, then refills both with the
+ * fresh fetch. LRU TTL is 15 minutes, so iterations 2..10 hit the LRU
+ * and return iteration-1's payload forever. If the underlying protocol
+ * (puppet-phoenix etc.) was still propagating the alias change at the
+ * moment of iteration 1, the 9 follow-up retries become no-ops and
+ * `alias()` throws "still got old alias after 10 tries".
+ *
+ * The fix moves contactPayloadDirty INTO the loop so every retry
+ * forces a fresh fetch. This test pins that contract: under a forced
+ * stale-read scenario, contactPayloadDirty must be called more than
+ * once.
+ */
+test('alias() must call contactPayloadDirty on every poll iteration', { timeout: 15_000 }, async t => {
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  // Swallow the wechaty-level error the alias() impl re-emits after
+  // its 10 poll iterations all fail to confirm the new alias; without
+  // this, the unhandled 'error' event tears down the test.
+  wechaty.on('error', () => {})
+
+  const mockMe   = puppet.mocker.createContact({ name: 'me' })
+  const mockUser = puppet.mocker.createContact({ name: 'Alice' })
+
+  await wechaty.start()
+  await puppet.mocker.login(mockMe)
+
+  let dirtyCount = 0
+  puppet.contactPayloadDirty = async (_: string) => {
+    dirtyCount++
+  }
+
+  // Simulate the protocol-layer "alias write accepted" but
+  // payload reads keep returning the OLD alias — the exact stuck
+  // scenario the polling loop is supposed to wait out.
+  puppet.contactAlias = async (_id: string, _newAlias: string) => {}
+  puppet.contactPayload = async (id: string) => ({
+    id,
+    alias: 'OLD',
+    name:  'Alice',
+  })
+
+  const contact = await wechaty.Contact.find({ id: mockUser.id })
+  t.ok(contact, 'sanity: find returned a contact')
+
+  // alias() traps internally and emits through wechaty error channel.
+  // We do NOT assert on the throw — only on dirty-call cadence.
+  await contact!.alias('NEW')
+
+  t.ok(
+    dirtyCount > 1,
+    `contactPayloadDirty must be called inside the retry loop, not just once before it; got ${dirtyCount}`,
+  )
+
+  await wechaty.stop()
+})

--- a/src/user-modules/contact-alias-polling.spec.ts
+++ b/src/user-modules/contact-alias-polling.spec.ts
@@ -24,7 +24,7 @@ import { WechatyBuilder } from '../wechaty-builder.js'
  * stale-read scenario, contactPayloadDirty must be called more than
  * once.
  */
-test('alias() must call contactPayloadDirty on every poll iteration', { timeout: 15_000 }, async t => {
+test('alias() must call contactPayloadDirty on every poll iteration', async t => {
   const puppet = new PuppetMock() as any
   const wechaty = WechatyBuilder.build({ puppet })
 

--- a/src/user-modules/contact.ts
+++ b/src/user-modules/contact.ts
@@ -496,22 +496,31 @@ class ContactMixin extends MixinBase implements SayableSayer {
 
     try {
       await this.wechaty.puppet.contactAlias(this.id, newAlias)
-      await this.wechaty.puppet.contactPayloadDirty(this.id)
 
       /**
        * In normal puppet, the dirty event handler, onDirty, is a sync function, so the contactPayload will get the new payload
        * However for wechaty-puppet-service, it uses flashstore to cache payloads, and deleting a cache is an async function
-       * So there is a chance contactPayload will still get old contact
+       * So there is a chance contactPayload will still get old contact.
+       *
+       * The puppet LRU TTL (15min) is far longer than the 300ms retry
+       * tick, so a dirty fired ONCE before the loop only invalidates
+       * the cache for iteration 1 — the iteration-1 fetch immediately
+       * refills both LRU and FlashStore, and iterations 2..10 hit the
+       * LRU and return iteration-1's payload forever. Dirty must fire
+       * on every retry so every read goes to source.
        */
       let maxCheck = 10
       let changed = false
       while (maxCheck-- > 0 && !changed) {
-        await new Promise(resolve => {
-          setTimeout(resolve, 300)
-        })
+        await this.wechaty.puppet.contactPayloadDirty(this.id)
         this.payload = await this.wechaty.puppet.contactPayload(this.id)
         const payloadAlias = this.payload.alias || ''
         changed = newAlias === payloadAlias
+        if (!changed) {
+          await new Promise(resolve => {
+            setTimeout(resolve, 300)
+          })
+        }
       }
       if (!changed) {
         throw new Error('failed to modify clias, still got old alias after 10 tries')

--- a/src/wechaty-mixins/puppet-mixin-dirty-call.spec.ts
+++ b/src/wechaty-mixins/puppet-mixin-dirty-call.spec.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+
+import { test }        from 'tstest'
+import * as PUPPET     from '@juzi/wechaty-puppet'
+import { PuppetMock }  from '@juzi/wechaty-puppet-mock'
+
+import { WechatyBuilder } from '../wechaty-builder.js'
+
+/**
+ * Regression: the dirty event listener for `Payload.Call` in `puppet-mixin`
+ * used to do `await this.puppet.callPayloadDirty(payloadId)` inside the
+ * handler itself.
+ *
+ * Under wechaty-puppet-service, `callPayloadDirty` fires a gRPC
+ * `DirtyPayload` to the server, which then re-emits `dirty` back to the
+ * client through the event stream. That re-emit triggers the handler
+ * again, forming an infinite client⇄server feedback loop.
+ *
+ * All other dirty branches (Contact / Room / Message / Wxxd*) only call
+ * `find(...).ready(true)`; the Call branch was the outlier.
+ *
+ * The fix removes the in-handler `callPayloadDirty` call so the branch
+ * matches the rest of the template. This test pins that contract:
+ * emitting a Call-typed dirty event must NOT cause the handler to call
+ * `puppet.callPayloadDirty` again.
+ */
+test('dirty(Call) handler must NOT call callPayloadDirty (would form a gRPC loop)', async t => {
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  await wechaty.start()
+
+  let dirtyCallCount = 0
+  const originalCallPayloadDirty = puppet.callPayloadDirty.bind(puppet)
+  puppet.callPayloadDirty = async (id: string) => {
+    dirtyCallCount++
+    return originalCallPayloadDirty(id)
+  }
+
+  puppet.emit('dirty', {
+    payloadType: PUPPET.types.Payload.Call,
+    payloadId:   'call-id-x',
+  })
+
+  // Allow the async handler to run.
+  await new Promise(resolve => setTimeout(resolve, 50))
+
+  t.equal(
+    dirtyCallCount,
+    0,
+    `dirty(Call) handler must not re-invoke callPayloadDirty; got ${dirtyCallCount} call(s)`,
+  )
+
+  await wechaty.stop()
+})

--- a/src/wechaty-mixins/puppet-mixin.ts
+++ b/src/wechaty-mixins/puppet-mixin.ts
@@ -753,16 +753,21 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                   }
                   case PUPPET.types.Payload.Call: {
                     /**
-                     * Invalidate the puppet-side cache so the next callPayload()
-                     * pull reflects the latest server state, then refresh the
-                     * user-layer Call payload so getters (media / participants /
-                     * endTime) reflect the new view immediately. Whether the
-                     * call is still alive is still decided by the call-event
-                     * handler via __finalizeIfEnded; we do not touch the pool
-                     * here, and we do not emit a synthetic user event — the
-                     * UI is expected to read getters when it needs the value.
+                     * Refresh the user-layer Call payload so getters (media /
+                     * participants / endTime) reflect the new view. Whether
+                     * the call is still alive is still decided by the
+                     * call-event handler via __finalizeIfEnded; we do not
+                     * touch the pool here, and we do not emit a synthetic
+                     * user event — the UI is expected to read getters when
+                     * it needs the value.
+                     *
+                     * IMPORTANT: do NOT call puppet.callPayloadDirty here.
+                     * Under puppet-service that fires a gRPC DirtyPayload
+                     * which the server bounces back as another `dirty`
+                     * event, forming an infinite client⇄server feedback
+                     * loop. Cache invalidation is already handled by the
+                     * cache-mixin onDirty listener registered alongside.
                      */
-                    await this.puppet.callPayloadDirty(payloadId)
                     const call = this.__callPool.get(payloadId)
                     if (call) {
                       try {


### PR DESCRIPTION
## Summary

两个独立的 dirty / cache 相关 bug，从 cache-system audit 收尾的一批。每个 bug 一红一绿两个 commit。

### Bug 1 — `dirty(Call)` handler 触发跨 gRPC 死循环
- **位置**：`src/wechaty-mixins/puppet-mixin.ts` Call 分支
- **根因**：handler 内部 \`await this.puppet.callPayloadDirty(payloadId)\`，而 Contact / Room / Message / WxxdProduct / WxxdOrder 5 个其他分支都没这么写。在 puppet-service 下 \`callPayloadDirty\` 发 gRPC \`DirtyPayload\` → 服务端 emit dirty → stream 回 client → handler 又跑 → 无限环路
- **修复**：删除那行 \`callPayloadDirty\`，对齐其他分支模板。LRU 失效兜底由 puppet 包内 \`CacheMixin\` 自挂的 \`puppet.on('dirty', onDirty)\` 同步抹掉

### Bug 5 — \`Contact.alias()\` 轮询绕过 stale LRU
- **位置**：\`src/user-modules/contact.ts:alias()\`
- **根因**：\`contactPayloadDirty\` 在 \`while (maxCheck-- > 0)\` **外**只清一次；iter 1 fetch 后 fresh 值立即写回 LRU（TTL 15min），iter 2..10 全部 LRU HIT，永远返回 iter 1 的值。如果协议层在 iter 1 时还没反映新 alias，9 次重试全是 no-op，最终 \"failed to modify clias, still got old alias after 10 tries\"
- **修复**：把 \`contactPayloadDirty\` 移进循环每次都清；sleep 仅在非首次失败时执行（节省末轮的无意义 300ms）

不需要新增 \`contactPayloadHardReload\` 类 API：现有 \`contactPayloadDirty\` 经 \`__dirtyPayloadAwait\` 已同时清 LRU + FlashStore 两层。

## Commits
- 96c626f test(puppet-mixin): cover dirty(Call) self-reentrant gRPC loop
- ab939aa fix(puppet-mixin): drop in-handler callPayloadDirty to break gRPC loop
- 1bd038b test(contact): cover alias() polling stale-LRU bypass
- 2108d95 fix(contact): dirty cache on every alias poll to bypass stale LRU

## Test plan
- [x] 单元测试：\`puppet-mixin-dirty-call.spec.ts\` 红测试断 \`got 1\`，绿测试断 \`got 0\`
- [x] 单元测试：\`contact-alias-polling.spec.ts\` 红测试断 \`got 1\`，绿测试断 \`got 10\`（每轮都 dirty）
- [ ] 集成验证：在装了 puppet-service 的 bot 上触发 \`Call.invite\` → \`hangup\`，确认日志里不再有刷屏式 \`DirtyPayload\` RPC
- [ ] 集成验证：在 alias 协议传播较慢的 puppet（如 puppet-phoenix）下调 \`contact.alias(new)\`，确认 10 次轮询内能拿到新值

## Notes
- juzi-cto Round 2 review 已过（CRITICAL/HIGH 0 条，2 MEDIUM / 3 LOW 都是 nice-to-have，未阻塞）
- 配套修复在另两个仓：[wechaty-puppet#99](https://github.com/juzibot/wechaty-puppet/pull/99)（cache 硬化）/ [wechaty-puppet-service#94](https://github.com/juzibot/wechaty-puppet-service/pull/94)（dirty 系统硬化）