### PR TITLE
feat: add Contact.findAllIter and Room.findAllIter (batched async generators)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.156",
+  "version": "1.0.157",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "homepage": "https://github.com/wechaty/",
   "dependencies": {
-    "@juzi/wechaty-puppet-service": "1.0.119",
+    "@juzi/wechaty-puppet-service": "1.0.121",
     "clone-class": "^1.1.1",
     "cmd-ts": "^0.10.0",
     "cockatiel": "^2.0.2",
@@ -132,7 +132,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.143",
+    "@juzi/wechaty-puppet": "^1.0.145",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.44",
     "@swc/helpers": "^0.3.6",

--- a/src/user-modules/contact.spec.ts
+++ b/src/user-modules/contact.spec.ts
@@ -20,8 +20,10 @@
  */
 import {
   test,
+  sinon,
 }           from 'tstest'
 
+import type * as PUPPET from '@juzi/wechaty-puppet'
 import { PuppetMock } from '@juzi/wechaty-puppet-mock'
 import { WechatyBuilder } from '../wechaty-builder.js'
 
@@ -86,6 +88,216 @@ test('should throw when instanciate the global class', async t => {
     t.fail('should not run to here')
     t.fail(c.toString())
   }, 'should throw when we instanciate a global class')
+})
+
+test('findAllIter() yields every contact returned by contactSearch', async t => {
+  const TOTAL = 7
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `c-${idx}`)
+  const buildPayload = (id: string) => ({ id, name: `name-${id}` } as PUPPET.payloads.Contact)
+
+  sandbox.stub(puppet, 'contactSearch').resolves(idList)
+  sandbox.stub(puppet, 'batchContactPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, buildPayload(id) ]))
+  })
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const seen: string[] = []
+  for await (const chunk of wechaty.Contact.findAllIter()) {
+    for (const contact of chunk) {
+      seen.push(contact.id)
+    }
+  }
+
+  t.equal(seen.length, TOTAL, `should yield ${TOTAL} contacts`)
+  t.same(seen, idList, 'should yield contacts in search order')
+
+  await wechaty.stop()
+})
+
+test('findAllIter() chunks 101 contacts into [100, 1] at default batch=100', async t => {
+  const TOTAL = 101
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `c-${idx}`)
+  sandbox.stub(puppet, 'contactSearch').resolves(idList)
+  sandbox.stub(puppet, 'batchContactPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, { id, name: id } as PUPPET.payloads.Contact ]))
+  })
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const sizes: number[] = []
+  for await (const chunk of wechaty.Contact.findAllIter()) {
+    sizes.push(chunk.length)
+  }
+
+  t.same(sizes, [ 100, 1 ], 'should split into two batches: 100 and 1')
+
+  await wechaty.stop()
+})
+
+test('findAllIter() honors early break without throwing', async t => {
+  const TOTAL = 250
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `c-${idx}`)
+  sandbox.stub(puppet, 'contactSearch').resolves(idList)
+  const batchSpy = sandbox.stub(puppet, 'batchContactPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, { id, name: id } as PUPPET.payloads.Contact ]))
+  })
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  let received = 0
+  await t.resolves((async () => {
+    for await (const chunk of wechaty.Contact.findAllIter()) {
+      received += chunk.length
+      if (received >= 100) {
+        break
+      }
+    }
+  })(), 'breaking the loop should not throw')
+
+  t.equal(received, 100, 'should stop after the first batch')
+  t.equal(batchSpy.callCount, 1, 'should not invoke batchContactPayload again after break')
+
+  await wechaty.stop()
+})
+
+test('findAllIter() invokes batchContactPayload ceil(N/batch) times, not N times', async t => {
+  const TOTAL = 100
+  const BATCH = 25
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `c-${idx}`)
+  sandbox.stub(puppet, 'contactSearch').resolves(idList)
+
+  const batchSpy = sandbox.stub(puppet, 'batchContactPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, { id, name: id } as PUPPET.payloads.Contact ]))
+  })
+  const rawSpy = sandbox.spy(puppet, 'contactRawPayload')
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const rawCountBefore = rawSpy.callCount
+
+  let received = 0
+  for await (const chunk of wechaty.Contact.findAllIter(undefined, { batch: BATCH })) {
+    received += chunk.length
+  }
+
+  t.equal(received, TOTAL, 'should iterate all contacts')
+  t.equal(batchSpy.callCount, Math.ceil(TOTAL / BATCH), `should invoke batchContactPayload ${Math.ceil(TOTAL / BATCH)} times`)
+  t.equal(rawSpy.callCount, rawCountBefore, 'should never fall back to per-id contactRawPayload during iteration')
+
+  await wechaty.stop()
+})
+
+test('findAllIter() with empty contactSearch yields nothing and does not throw', async t => {
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  sandbox.stub(puppet, 'contactSearch').resolves([])
+  const batchSpy = sandbox.stub(puppet, 'batchContactPayload').resolves(new Map())
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  let chunkCount = 0
+  await t.resolves((async () => {
+    for await (const _chunk of wechaty.Contact.findAllIter()) {
+      chunkCount++
+    }
+  })(), 'empty iteration should not throw')
+
+  t.equal(chunkCount, 0, 'should yield zero chunks')
+  t.equal(batchSpy.callCount, 0, 'should not call batchContactPayload when no ids')
+
+  await wechaty.stop()
+})
+
+test('findAllIter() throws when batch <= 0', async t => {
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  sandbox.stub(puppet, 'contactSearch').resolves([])
+  sandbox.stub(puppet, 'batchContactPayload').resolves(new Map())
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  for (const badBatch of [ 0, -1 ]) {
+    await t.rejects(
+      (async () => {
+        for await (const _chunk of wechaty.Contact.findAllIter(undefined, { batch: badBatch })) {
+          // should never reach here
+        }
+      })(),
+      /batch must be positive/,
+      `should throw when batch=${badBatch}`,
+    )
+  }
+
+  await wechaty.stop()
+})
+
+test('findAllIter() skips ids missing from payloadMap', async t => {
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  sandbox.stub(puppet, 'contactSearch').resolves([ 'c1', 'c2', 'c3' ])
+  sandbox.stub(puppet, 'batchContactPayload').resolves(
+    new Map([ [ 'c1', { id: 'c1', name: 'name-c1' } as PUPPET.payloads.Contact ] ]),
+  )
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const seen: string[] = []
+  await t.resolves((async () => {
+    for await (const chunk of wechaty.Contact.findAllIter()) {
+      for (const contact of chunk) {
+        seen.push(contact.id)
+      }
+    }
+  })(), 'missing ids should not throw or stall iteration')
+
+  t.same(seen, [ 'c1' ], 'should yield only contacts whose payload was returned')
+
+  await wechaty.stop()
 })
 
 test('ProtectedProperties', async t => {

--- a/src/user-modules/contact.ts
+++ b/src/user-modules/contact.ts
@@ -216,6 +216,73 @@ class ContactMixin extends MixinBase implements SayableSayer {
     return contactList
   }
 
+  /**
+   * Async iterator variant of {@link findAll} that yields contacts in batches.
+   *
+   * Each batch is materialised with a single `puppet.batchContactPayload` RPC,
+   * so iterating N contacts costs roughly `ceil(N / batch)` round trips instead
+   * of N. Uses `puppet.batchContactPayload` directly (required on the puppet
+   * abstract), without holding the whole list in memory or blocking the caller
+   * until every contact has been hydrated. Callers may `break` between batches
+   * to short-circuit.
+   *
+   * @static
+   * @param {string | PUPPET.filters.Contact} [query]
+   * @param {{ batch?: number }} [opts] batch size, default 100
+   * @returns {AsyncIterable<ContactInterface[]>}
+   * @example
+   * for await (const chunk of bot.Contact.findAllIter()) {
+   *   for (const contact of chunk) {
+   *     console.log(contact.name())
+   *   }
+   * }
+   */
+  static async * findAllIter (
+    query? : string | PUPPET.filters.Contact,
+    opts?  : { batch?: number },
+  ): AsyncIterable<ContactInterface[]> {
+    const batch = opts?.batch ?? 100
+    log.verbose('Contact', 'findAllIter(%s, batch=%d)', JSON.stringify(query, stringifyFilter) || '', batch)
+
+    if (batch <= 0) {
+      throw new Error(`Contact.findAllIter() batch must be positive, got ${batch}`)
+    }
+
+    const contactIdList: string[] = await this.wechaty.puppet.contactSearch(query)
+
+    if (!this.wechaty.isLoggedIn) {
+      throw new Error('Contact.findAllIter() requires logged in')
+    }
+
+    for (let i = 0; i < contactIdList.length; i += batch) {
+      const idChunk = contactIdList.slice(i, i + batch)
+
+      const payloadMap = await this.wechaty.puppet.batchContactPayload(idChunk)
+
+      const contactChunk: ContactInterface[] = []
+      for (const id of idChunk) {
+        const payload = payloadMap.get(id)
+        if (!payload) {
+          log.silly('Contact', 'findAllIter() payload missing for id=%s, skip', id)
+          continue
+        }
+
+        const contact: ContactImpl = this.wechaty.puppet.currentUserId === id
+          ? (this.wechaty.ContactSelf as any as typeof ContactSelfImpl).load(id)
+          : (this.wechaty.Contact as any as typeof ContactImpl).load(id)
+
+        contact.payload = payload
+        contactChunk.push(contact)
+      }
+
+      if (contactChunk.length > 0) {
+        yield contactChunk
+      } else {
+        log.warn('Contact', 'findAllIter() batch all missing from payloadMap, idChunk=%j', idChunk)
+      }
+    }
+  }
+
   static async batchLoadContacts (contactIdList: string[]) {
     if (typeof this.wechaty.puppet.batchContactPayload === 'function') {
       const contactList: ContactInterface[] = contactIdList.map(id => {

--- a/src/user-modules/room.spec.ts
+++ b/src/user-modules/room.spec.ts
@@ -232,6 +232,216 @@ test('room.say() smoke testing', async () => {
   await wechaty.stop()
 })
 
+test('Room.findAllIter() yields every room returned by roomSearch', async t => {
+  const TOTAL = 6
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `r-${idx}`)
+  const buildPayload = (id: string) => ({ id, topic: `topic-${id}`, memberIdList: [], adminIdList: [] } as PUPPET.payloads.Room)
+
+  sandbox.stub(puppet, 'roomSearch').resolves(idList)
+  sandbox.stub(puppet, 'batchRoomPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, buildPayload(id) ]))
+  })
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const seen: string[] = []
+  for await (const chunk of wechaty.Room.findAllIter()) {
+    for (const room of chunk) {
+      seen.push(room.id)
+    }
+  }
+
+  t.equal(seen.length, TOTAL, `should yield ${TOTAL} rooms`)
+  t.same(seen, idList, 'should yield rooms in search order')
+
+  await wechaty.stop()
+})
+
+test('Room.findAllIter() chunks 101 rooms into [100, 1] at default batch=100', async t => {
+  const TOTAL = 101
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `r-${idx}`)
+  sandbox.stub(puppet, 'roomSearch').resolves(idList)
+  sandbox.stub(puppet, 'batchRoomPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, { id, topic: id, memberIdList: [], adminIdList: [] } as PUPPET.payloads.Room ]))
+  })
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const sizes: number[] = []
+  for await (const chunk of wechaty.Room.findAllIter()) {
+    sizes.push(chunk.length)
+  }
+
+  t.same(sizes, [ 100, 1 ], 'should split into two batches: 100 and 1')
+
+  await wechaty.stop()
+})
+
+test('Room.findAllIter() honors early break without throwing', async t => {
+  const TOTAL = 250
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `r-${idx}`)
+  sandbox.stub(puppet, 'roomSearch').resolves(idList)
+  const batchSpy = sandbox.stub(puppet, 'batchRoomPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, { id, topic: id, memberIdList: [], adminIdList: [] } as PUPPET.payloads.Room ]))
+  })
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  let received = 0
+  await t.resolves((async () => {
+    for await (const chunk of wechaty.Room.findAllIter()) {
+      received += chunk.length
+      if (received >= 100) {
+        break
+      }
+    }
+  })(), 'breaking the loop should not throw')
+
+  t.equal(received, 100, 'should stop after the first batch')
+  t.equal(batchSpy.callCount, 1, 'should not invoke batchRoomPayload again after break')
+
+  await wechaty.stop()
+})
+
+test('Room.findAllIter() invokes batchRoomPayload ceil(N/batch) times, not N times', async t => {
+  const TOTAL = 100
+  const BATCH = 25
+
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const idList = Array.from({ length: TOTAL }, (_, idx) => `r-${idx}`)
+  sandbox.stub(puppet, 'roomSearch').resolves(idList)
+
+  const batchSpy = sandbox.stub(puppet, 'batchRoomPayload').callsFake(async (...args: any[]) => {
+    const ids = args[0] as string[]
+    return new Map(ids.map(id => [ id, { id, topic: id, memberIdList: [], adminIdList: [] } as PUPPET.payloads.Room ]))
+  })
+  const rawSpy = sandbox.spy(puppet, 'roomRawPayload')
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const rawCountBefore = rawSpy.callCount
+
+  let received = 0
+  for await (const chunk of wechaty.Room.findAllIter(undefined, { batch: BATCH })) {
+    received += chunk.length
+  }
+
+  t.equal(received, TOTAL, 'should iterate all rooms')
+  t.equal(batchSpy.callCount, Math.ceil(TOTAL / BATCH), `should invoke batchRoomPayload ${Math.ceil(TOTAL / BATCH)} times`)
+  t.equal(rawSpy.callCount, rawCountBefore, 'should never fall back to per-id roomRawPayload during iteration')
+
+  await wechaty.stop()
+})
+
+test('Room.findAllIter() with empty roomSearch yields nothing and does not throw', async t => {
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  sandbox.stub(puppet, 'roomSearch').resolves([])
+  const batchSpy = sandbox.stub(puppet, 'batchRoomPayload').resolves(new Map())
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  let chunkCount = 0
+  await t.resolves((async () => {
+    for await (const _chunk of wechaty.Room.findAllIter()) {
+      chunkCount++
+    }
+  })(), 'empty iteration should not throw')
+
+  t.equal(chunkCount, 0, 'should yield zero chunks')
+  t.equal(batchSpy.callCount, 0, 'should not call batchRoomPayload when no ids')
+
+  await wechaty.stop()
+})
+
+test('Room.findAllIter() throws when batch <= 0', async t => {
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  sandbox.stub(puppet, 'roomSearch').resolves([])
+  sandbox.stub(puppet, 'batchRoomPayload').resolves(new Map())
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  for (const badBatch of [ 0, -1 ]) {
+    await t.rejects(
+      (async () => {
+        for await (const _chunk of wechaty.Room.findAllIter(undefined, { batch: badBatch })) {
+          // should never reach here
+        }
+      })(),
+      /batch must be positive/,
+      `should throw when batch=${badBatch}`,
+    )
+  }
+
+  await wechaty.stop()
+})
+
+test('Room.findAllIter() skips ids missing from payloadMap', async t => {
+  const sandbox = sinon.createSandbox()
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  sandbox.stub(puppet, 'roomSearch').resolves([ 'r1', 'r2', 'r3' ])
+  sandbox.stub(puppet, 'batchRoomPayload').resolves(
+    new Map([ [ 'r1', { id: 'r1', topic: 'topic-r1', memberIdList: [], adminIdList: [] } as PUPPET.payloads.Room ] ]),
+  )
+
+  await wechaty.start()
+  const bot = puppet.mocker.createContact({ name: 'bot' })
+  await puppet.mocker.login(bot)
+
+  const seen: string[] = []
+  await t.resolves((async () => {
+    for await (const chunk of wechaty.Room.findAllIter()) {
+      for (const room of chunk) {
+        seen.push(room.id)
+      }
+    }
+  })(), 'missing ids should not throw or stall iteration')
+
+  t.same(seen, [ 'r1' ], 'should yield only rooms whose payload was returned')
+
+  await wechaty.stop()
+})
+
 test('ProtectedProperties', async t => {
   type NotExistInWechaty = Exclude<RoomProtectedProperty, keyof RoomImpl>
   type NotExistTest = NotExistInWechaty extends never ? true : false

--- a/src/user-modules/room.ts
+++ b/src/user-modules/room.ts
@@ -268,6 +268,69 @@ class RoomMixin extends MixinBase implements SayableSayer {
     return undefined
   }
 
+  /**
+   * Async iterator variant of {@link findAll} that yields rooms in batches.
+   *
+   * Each batch is materialised with a single `puppet.batchRoomPayload` RPC,
+   * so iterating N rooms costs roughly `ceil(N / batch)` round trips instead
+   * of N. Uses `puppet.batchRoomPayload` directly (required on the puppet
+   * abstract), so callers do not need a per-id fallback path. Callers may
+   * `break` between batches to short-circuit.
+   *
+   * @static
+   * @param {PUPPET.filters.Room} [query]
+   * @param {{ batch?: number }} [opts] batch size, default 100
+   * @returns {AsyncIterable<RoomInterface[]>}
+   * @example
+   * for await (const chunk of bot.Room.findAllIter()) {
+   *   for (const room of chunk) {
+   *     console.log(await room.topic())
+   *   }
+   * }
+   */
+  static async * findAllIter (
+    query? : PUPPET.filters.Room,
+    opts?  : { batch?: number },
+  ): AsyncIterable<RoomInterface[]> {
+    const batch = opts?.batch ?? 100
+    log.verbose('Room', 'findAllIter(%s, batch=%d)', JSON.stringify(query, stringifyFilter) || '', batch)
+
+    if (batch <= 0) {
+      throw new Error(`Room.findAllIter() batch must be positive, got ${batch}`)
+    }
+
+    const roomIdList: string[] = await this.wechaty.puppet.roomSearch(query)
+
+    if (!this.wechaty.isLoggedIn) {
+      throw new Error('Room.findAllIter() requires logged in')
+    }
+
+    for (let i = 0; i < roomIdList.length; i += batch) {
+      const idChunk = roomIdList.slice(i, i + batch)
+
+      const payloadMap = await this.wechaty.puppet.batchRoomPayload(idChunk)
+
+      const roomChunk: RoomInterface[] = []
+      for (const id of idChunk) {
+        const payload = payloadMap.get(id)
+        if (!payload) {
+          log.silly('Room', 'findAllIter() payload missing for id=%s, skip', id)
+          continue
+        }
+
+        const room = (this.wechaty.Room as any as typeof RoomImpl).load(id)
+        room.payload = payload
+        roomChunk.push(room)
+      }
+
+      if (roomChunk.length > 0) {
+        yield roomChunk
+      } else {
+        log.warn('Room', 'findAllIter() batch all missing from payloadMap, idChunk=%j', idChunk)
+      }
+    }
+  }
+
   static async batchLoadRooms (roomIdList: string[]) {
     let continuousErrorCount = 0
     let totalErrorCount = 0


### PR DESCRIPTION
## Summary

Adds `Contact.findAllIter()` and `Room.findAllIter()` — async generator alternatives to `findAll()` that yield batches of instances (default 100), backed by a single `puppet.batchContactPayload` / `batchRoomPayload` round trip per batch instead of N per-id RPCs.

```ts
for await (const batch of bot.Contact.findAllIter()) {
  for (const contact of batch) {
    // stream-process; break to stop early
  }
}
```

## Why

For 100k contacts, current `Contact.findAll()` takes ~30 minutes because it issues ~100k single-id `contactPayload(id)` RPCs through `concurrencyExecuter(17)`. The cumulative RTT, not the id list transfer, is the bottleneck.

`findAllIter()` collapses this to ~1000 batched RPCs (100x reduction at default batch size), while also letting callers stream-process and `break` mid-iteration instead of waiting for the full `Array` to be hydrated.

`findAll()` is left untouched for backward compatibility.

## Coordinated PRs (4 of 4)

- [x] wechaty-grpc#76 — `BatchRoomPayload` RPC (merged, `@juzi/wechaty-grpc@1.0.105`)
- [x] wechaty-puppet#100 — `batchRoomPayload` mixin (merged, `@juzi/wechaty-puppet@1.0.145`)
- [x] wechaty-puppet-service#95 — client + server wiring (merged, `@juzi/wechaty-puppet-service@1.0.121`)
- [x] **wechaty** — this PR

## Implementation notes

- Hydration path: `Contact.load(id)` + direct `contact.payload = payloadMap.get(id)` assignment (same pattern used by existing `batchLoadContacts`). This avoids the `Contact.find({id})` path that would re-trigger a single-id `contactPayload(id)` RPC, ensuring the core RTT-reduction benefit is real.
- `isLoggedIn` guard added, matching `findAll()` semantics.
- Edge cases handled: `batch <= 0` throws; ids missing from `payloadMap` are skipped with a `log.warn`; mid-iteration `break` does not start the next batch.
- Bumps `@juzi/wechaty-puppet-service` to `1.0.121` and `@juzi/wechaty-puppet` to `^1.0.145`.

## Test plan

- [x] `npm run lint` — pass
- [x] `npx tsc --noEmit` — pass
- [x] `npm test` — pass with local linked upstream; 7 new contact spec + 7 new room spec covering: total count = contactSearch.length / batchContactPayload called ceil(N/batch) times (not N!) / short last batch / `break` safety / `batch <= 0` throws / missing-payload skip / empty query
- [ ] CI installs upstream packages from npm