### PR TITLE
chore: bump wechaty-puppet to 1.0.158 for callId support

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.145",
+    "@juzi/wechaty-puppet": "^1.0.146",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.44",
     "@swc/helpers": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.157",
+  "version": "1.0.158",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bump `@juzi/wechaty-puppet` to 1.0.146 (adds `CallRecordPayload.callId` field).
- Release version `1.0.158`.
- No business logic changes in this repo; purely a dependency bump to propagate the new `callId` field surfaced by upstream puppet.

## Upstream chain

- wechaty-grpc: https://github.com/juzibot/wechaty-grpc/pull/77
- wechaty-puppet: https://github.com/juzibot/wechaty-puppet/pull/101
- wechaty-puppet-service: PR forthcoming

## Test plan

- [x] `npm run lint` green (lint:es / lint:ts / lint:md)
- [x] `npm test` (tap) green