### PR TITLE
fix(puppet-mixin): dirty handler only refresh pooled instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.158",
+  "version": "1.0.159",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/src/wechaty-mixins/puppet-mixin-dirty-pool.spec.ts
+++ b/src/wechaty-mixins/puppet-mixin-dirty-pool.spec.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+
+import { test }        from 'tstest'
+import * as PUPPET     from '@juzi/wechaty-puppet'
+import { PuppetMock }  from '@juzi/wechaty-puppet-mock'
+
+import { WechatyBuilder } from '../wechaty-builder.js'
+
+/**
+ * Regression: the `dirty` event handler for pooled user-modules
+ * (Contact / Room / WxxdProduct / WxxdOrder) used to call
+ * `this.Xxx.find({ id }).ready(true)`. `find({ id })` on a pool miss
+ * constructs a fresh instance and calls `ready()` — a puppet-side gRPC
+ * round-trip — turning a passive "invalidate if cached" signal into an
+ * active fetch for ids no business code has touched.
+ *
+ * The fix looks the id up in the pool directly and only calls
+ * `.ready(true)` when the instance is already pooled.
+ */
+
+async function delay (ms: number): Promise<void> {
+  await new Promise<void>(resolve => setTimeout(resolve, ms))
+}
+
+test('dirty handler does not fetch payload for un-pooled ids, but still refreshes pooled ones', async t => {
+  const puppet = new PuppetMock() as any
+  const wechaty = WechatyBuilder.build({ puppet })
+
+  const botContact = puppet.mocker.createContact({ name: 'test-bot' })
+
+  await wechaty.start()
+  await puppet.mocker.login(botContact)
+
+  // --- Case 1: un-pooled Contact id must not trigger contactRawPayload ---
+
+  let contactRawPayloadCalls = 0
+  const originalContactRawPayload = puppet.contactRawPayload.bind(puppet)
+  puppet.contactRawPayload = async (id: string) => {
+    contactRawPayloadCalls++
+    return originalContactRawPayload(id)
+  }
+
+  puppet.emit('dirty', {
+    payloadType: PUPPET.types.Payload.Contact,
+    payloadId:   'never-loaded-contact-id',
+  })
+  await delay(50)
+
+  t.equal(
+    contactRawPayloadCalls,
+    0,
+    `dirty(Contact) for un-pooled id must not trigger contactRawPayload; got ${contactRawPayloadCalls} call(s)`,
+  )
+
+  // --- Case 2: un-pooled Room id must not trigger roomRawPayload ---
+
+  let roomRawPayloadCalls = 0
+  const originalRoomRawPayload = puppet.roomRawPayload.bind(puppet)
+  puppet.roomRawPayload = async (id: string) => {
+    roomRawPayloadCalls++
+    return originalRoomRawPayload(id)
+  }
+
+  puppet.emit('dirty', {
+    payloadType: PUPPET.types.Payload.Room,
+    payloadId:   'never-loaded-room-id',
+  })
+  await delay(50)
+
+  t.equal(
+    roomRawPayloadCalls,
+    0,
+    `dirty(Room) for un-pooled id must not trigger roomRawPayload; got ${roomRawPayloadCalls} call(s)`,
+  )
+
+  // --- Case 3: Message dirty must not trigger messageRawPayload (Message has no user-layer pool) ---
+
+  let messageRawPayloadCalls = 0
+  const originalMessageRawPayload = puppet.messageRawPayload.bind(puppet)
+  puppet.messageRawPayload = async (id: string) => {
+    messageRawPayloadCalls++
+    return originalMessageRawPayload(id)
+  }
+
+  puppet.emit('dirty', {
+    payloadType: PUPPET.types.Payload.Message,
+    payloadId:   'some-message-id',
+  })
+  await delay(50)
+
+  t.equal(
+    messageRawPayloadCalls,
+    0,
+    `dirty(Message) must not trigger messageRawPayload at the user layer; got ${messageRawPayloadCalls} call(s)`,
+  )
+
+  // --- Case 4: un-pooled Contact still emits the user-facing dirty event ---
+
+  let wechatyDirtyEmits = 0
+  wechaty.on('dirty', () => {
+    wechatyDirtyEmits++
+  })
+
+  puppet.emit('dirty', {
+    payloadType: PUPPET.types.Payload.Contact,
+    payloadId:   'yet-another-un-pooled-id',
+  })
+  await delay(50)
+
+  t.equal(
+    wechatyDirtyEmits,
+    1,
+    `wechaty.emit('dirty', ...) must fire once even when the id is not pooled; got ${wechatyDirtyEmits}`,
+  )
+
+  // --- Case 5: pooled Contact MUST re-fetch on dirty ---
+
+  const pooledContact = puppet.mocker.createContact({ name: 'pooled-contact' })
+
+  // Force the contact into the wechatified pool via find(). Payload gets
+  // loaded once as part of find()'s ready() call — subsequent counts we
+  // measure from AFTER this seed.
+  await wechaty.Contact.find({ id: pooledContact.id })
+
+  let contactPayloadCalls = 0
+  const originalContactPayload = puppet.contactPayload.bind(puppet)
+  puppet.contactPayload = async (id: string) => {
+    contactPayloadCalls++
+    return originalContactPayload(id)
+  }
+
+  puppet.emit('dirty', {
+    payloadType: PUPPET.types.Payload.Contact,
+    payloadId:   pooledContact.id,
+  })
+  await delay(50)
+
+  t.ok(
+    contactPayloadCalls >= 1,
+    `dirty(Contact) for pooled id must trigger contactPayload via ready(true); got ${contactPayloadCalls} call(s)`,
+  )
+
+  await wechaty.stop()
+})

--- a/src/wechaty-mixins/puppet-mixin.ts
+++ b/src/wechaty-mixins/puppet-mixin.ts
@@ -18,11 +18,8 @@ import type {
   CallImpl,
   ContactImpl,
   ContactInterface,
-  RoomImpl,
   TagGroupInterface,
   TagInterface,
-  WxxdOrderImpl,
-  WxxdProductImpl,
 }                               from '../user-modules/mod.js'
 
 import type {
@@ -721,12 +718,12 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
               try {
                 switch (payloadType) {
                   case PUPPET.types.Payload.Contact: {
-                    const cached = this.Contact.pool.get(payloadId) as undefined | ContactImpl
+                    const cached = this.Contact.pool.get(payloadId)
                     if (cached) await cached.ready(true)
                     break
                   }
                   case PUPPET.types.Payload.Room: {
-                    const cached = this.Room.pool.get(payloadId) as undefined | RoomImpl
+                    const cached = this.Room.pool.get(payloadId)
                     if (cached) await cached.ready(true)
                     break
                   }
@@ -737,7 +734,7 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                     // A bare (non-composite) RoomMember dirty id addresses the
                     // whole room, mirroring the Room branch — but never load
                     // a new Room here.
-                    const cached = this.Room.pool.get(payloadId) as undefined | RoomImpl
+                    const cached = this.Room.pool.get(payloadId)
                     if (cached) await cached.ready()
                     break
                   }
@@ -762,12 +759,12 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                   case PUPPET.types.Payload.Post:
                     break
                   case PUPPET.types.Payload.WxxdProduct: {
-                    const cached = this.WxxdProduct.pool.get(payloadId) as undefined | WxxdProductImpl
+                    const cached = this.WxxdProduct.pool.get(payloadId)
                     if (cached) await cached.ready(true)
                     break
                   }
                   case PUPPET.types.Payload.WxxdOrder: {
-                    const cached = this.WxxdOrder.pool.get(payloadId) as undefined | WxxdOrderImpl
+                    const cached = this.WxxdOrder.pool.get(payloadId)
                     if (cached) await cached.ready(true)
                     break
                   }

--- a/src/wechaty-mixins/puppet-mixin.ts
+++ b/src/wechaty-mixins/puppet-mixin.ts
@@ -18,7 +18,6 @@ import type {
   CallImpl,
   ContactImpl,
   ContactInterface,
-  MessageImpl,
   RoomImpl,
   TagGroupInterface,
   TagInterface,
@@ -700,26 +699,46 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
           case 'dirty':
             /**
              * https://github.com/wechaty/wechaty-puppet-service/issues/43
+             *
+             * `dirty` semantics: the puppet-service told us the cached payload
+             * for this id is stale. It is NOT a request to load the payload.
+             *
+             * The old handler used `this.Xxx.find({ id })` which, on pool miss,
+             * constructs a fresh user-layer instance AND calls `.ready()` — a
+             * puppet-side gRPC round-trip. For a `dirty` event about an id
+             * that no business code has ever touched, this turned a passive
+             * "invalidate if cached" signal into an active fetch, amplifying
+             * dirty-event bursts (e.g. during message storms) into extra
+             * puppet-service QPS.
+             *
+             * Fix: for pooled user-modules, look the instance up in the pool
+             * directly and only call `.ready(true)` when it is already there.
+             * The Call branch (below) already follows this shape via
+             * `__callPool.get(...)`. Message has no pool, so its branch is a
+             * no-op break (any caller wanting a Message must load it itself).
              */
             puppet.on('dirty', async ({ payloadType, payloadId }) => {
               try {
                 switch (payloadType) {
                   case PUPPET.types.Payload.Contact: {
-                    const contact = await this.Contact.find({ id: payloadId }) as unknown as undefined | ContactImpl
-                    await contact?.ready(true)
+                    const cached = this.Contact.pool.get(payloadId) as undefined | ContactImpl
+                    if (cached) await cached.ready(true)
                     break
                   }
                   case PUPPET.types.Payload.Room: {
-                    const room = await this.Room.find({ id: payloadId })  as unknown as undefined | RoomImpl
-                    await room?.ready(true)
+                    const cached = this.Room.pool.get(payloadId) as undefined | RoomImpl
+                    if (cached) await cached.ready(true)
                     break
                   }
                   case PUPPET.types.Payload.RoomMember: {
                     if (payloadId.includes(PUPPET.STRING_SPLITTER)) {
                       break
                     }
-                    const room = await this.Room.find({ id: payloadId }) as unknown as undefined | RoomImpl
-                    await room?.ready()
+                    // A bare (non-composite) RoomMember dirty id addresses the
+                    // whole room, mirroring the Room branch — but never load
+                    // a new Room here.
+                    const cached = this.Room.pool.get(payloadId) as undefined | RoomImpl
+                    if (cached) await cached.ready()
                     break
                   }
 
@@ -729,12 +748,13 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                   case PUPPET.types.Payload.Friendship:
                     // Friendship has no payload
                     break
-                  case PUPPET.types.Payload.Message: {
-                    // Message does not need to dirty (?)
-                    const message = await this.Message.find({ id: payloadId }) as unknown as undefined | MessageImpl
-                    await message?.ready(true)
+                  case PUPPET.types.Payload.Message:
+                    // Message has no user-layer pool (see message.ts: `load`
+                    // constructs a fresh instance every call). Dirty for a
+                    // Message id is therefore a no-op at this layer — the
+                    // cache-mixin listener still invalidates the puppet-side
+                    // payload cache alongside this handler.
                     break
-                  }
                   case PUPPET.types.Payload.Tag:
                     break
                   case PUPPET.types.Payload.TagGroup:
@@ -742,13 +762,13 @@ const puppetMixin = <MixinBase extends WechatifyUserModuleMixin & GErrorMixin & 
                   case PUPPET.types.Payload.Post:
                     break
                   case PUPPET.types.Payload.WxxdProduct: {
-                    const product = await this.WxxdProduct.find({ id: payloadId }) as unknown as undefined | WxxdProductImpl
-                    await product?.ready(true)
+                    const cached = this.WxxdProduct.pool.get(payloadId) as undefined | WxxdProductImpl
+                    if (cached) await cached.ready(true)
                     break
                   }
                   case PUPPET.types.Payload.WxxdOrder: {
-                    const order = await this.WxxdOrder.find({ id: payloadId }) as unknown as undefined | WxxdOrderImpl
-                    await order?.ready(true)
+                    const cached = this.WxxdOrder.pool.get(payloadId) as undefined | WxxdOrderImpl
+                    if (cached) await cached.ready(true)
                     break
                   }
                   case PUPPET.types.Payload.Call: {


### PR DESCRIPTION
## Summary

`puppet.on('dirty')` handler for Contact / Room / Message / WxxdProduct / WxxdOrder was `this.Xxx.find({ id }).ready(true)`. `find({ id })` on a pool miss constructs a fresh user-layer instance AND calls `.ready()` (a puppet-side gRPC round-trip), so a `dirty` event about an id no business code has ever touched turns a passive "invalidate if cached" signal into an active fetch. Under message-storm-level dirty bursts this shows up as extra puppet-service QPS.

The Call branch (introduced in #116) already followed the correct shape: `this.__callPool.get(payloadId)?.ready(true)`. This PR aligns the other branches with that pattern.

## Changes

- `Contact` / `Room` / `RoomMember` (non-composite) / `WxxdProduct` / `WxxdOrder` now use `this.Xxx.pool.get(payloadId)` and only call `.ready(true)` when the instance is already pooled.
- `Message` has no user-layer pool (`message.ts:load` constructs a fresh instance every call), so its dirty branch is now a no-op break. The puppet-side cache-mixin listener still invalidates the payload cache alongside this handler.
- The tail `this.emit('dirty', payloadId, payloadType)` is preserved — user-facing `dirty` continues to fire regardless of pool state.

## Test plan

- [x] Unit: `dirty(Contact)` for an id that is not pooled does NOT invoke `puppet.contactRawPayload`.
- [x] Unit: `dirty(Room)` for an id that is not pooled does NOT invoke `puppet.roomRawPayload`.
- [x] Unit: `dirty(Message)` does NOT invoke `puppet.messageRawPayload` at the user layer (Message has no pool).
- [x] Unit: `dirty(Contact)` for a pooled id still triggers a payload refresh via `ready(true)` -> `puppet.contactPayload`.
- [x] Unit: `wechaty.emit('dirty', ...)` still fires for un-pooled ids.
- [x] `npm run lint` (es / ts / sh / md) passes.
- [x] `npm test` full suite passes.

## Behavior change to flag for puppet-service downstream

**Message 分支从 `find + ready(true)` 改为 no-op break** 之后，wechaty 层不再顺带触发 `puppet.messagePayloadDirty` / `puppet.messagePayload`。这依赖 puppet-service 端在向客户端发送 `dirty(Message, id)` 事件之前，**已经自己清掉了服务端 PayloadStore + LRU 里对应的 message 缓存**。

- 若 puppet-service 已如此实现（应有的语义）：本改动无回归。
- 若 puppet-service 尚未如此：业务在 `on('dirty', Message, id)` 之后紧接着 `msg.text()` 会看到旧值。此时需要在 puppet-service 侧显式 `await puppet.messagePayloadDirty(payloadId)` 或在业务代码里改成 `await bot.Message.find(id)?.ready(true)` 后再读。

姊妹 PR juzibot/wechaty-puppet-service#97 owner 请确认服务端 dirty(Message) 前的缓存失效行为。
