### PR TITLE
ci: pin npm 11 in publish job (npm 12 breaks lifecycle scripts and npm publish)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -65,8 +65,13 @@ jobs:
           cache: npm
           cache-dependency-path: package.json
 
-      - name: Install npm
-        run: curl -qL https://www.npmjs.com/install.sh | sh
+      # Pin npm 11: npm 12 skips dependency lifecycle scripts by default
+      # (node-jq never fetches its jq binary, breaking pkg-jq) and its
+      # in-place upgrade over the bundled npm corrupts `npm publish`
+      # (Cannot find module 'sigstore'). npm 11 behaves like the runs
+      # that published successfully before 2026-07.
+      - name: Install npm 11
+        run: npm install -g npm@11
 
       - run: npm install
       - name: Generate Package JSON


### PR DESCRIPTION
同 juzibot/wechaty-puppet#110：Publish job 装 npm@latest 自 npm 12 起跳过依赖 lifecycle scripts（node-jq 拿不到 jq 二进制 → pkg-jq ENOENT，#121 合入后的发布 run 29082757168 即因此失败），且 install.sh 原地覆盖会破坏 npm publish（缺 sigstore）。钉 npm 11 恢复正常，合入后应能发布 1.0.161。

🤖 Generated with [Claude Code](https://claude.com/claude-code)