### PR TITLE
feat: Call.end() — universal terminator for the call session

### DIFF
--- a/src/user-modules/call.spec.ts
+++ b/src/user-modules/call.spec.ts
@@ -931,3 +931,206 @@ test('dirty(Call) refreshes user-layer payload so getters see new value', async 
   await wechaty.stop()
   sandbox.restore()
 })
+
+// ---------------------------------------------------------------------------
+// 12. end() — universal terminator dispatches by state
+// ---------------------------------------------------------------------------
+
+test('call.end() on outgoing calling invokes puppet.callCancel and ends', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  puppet.callInvite = sandbox.stub().resolves('call-id-end-cancel')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const cancelStub = sandbox.stub().resolves(undefined)
+  const hangupStub = sandbox.stub().resolves(undefined)
+  puppet.callCancel = cancelStub
+  puppet.callHangup = hangupStub
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
+  t.equal(call.status(), 'calling', 'prerequisite: outgoing call starts as calling')
+
+  await call.end('demo')
+  t.same(cancelStub.firstCall.args, [ call.id ], 'callCancel should be invoked with callId')
+  t.equal(hangupStub.callCount, 0, 'callHangup should not be touched')
+  t.equal(call.status(), 'ended', 'status should be ended')
+  t.equal((wechaty as any).__callPool.has(call.id), false, 'pool should be evicted')
+
+  await call.end('again')
+  t.equal(cancelStub.callCount, 1, 'second end() should be a no-op')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('call.end() on connected call invokes puppet.callHangup with reason', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  puppet.callInvite = sandbox.stub().resolves('call-id-end-hangup')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const cancelStub = sandbox.stub().resolves(undefined)
+  const hangupStub = sandbox.stub().resolves(undefined)
+  puppet.callCancel = cancelStub
+  puppet.callHangup = hangupStub
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
+
+  ;(puppet as any).emit('call', {
+    callId    : call.id,
+    signal    : PUPPET.types.CallSignal.Accept,
+    contactId : 'peer',
+    timestamp : 2,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+  t.equal(call.status(), 'connected', 'prerequisite: call should be connected')
+
+  await call.end('bye')
+  t.same(hangupStub.firstCall.args, [ call.id, 'bye' ], 'callHangup args should be [callId, reason]')
+  t.equal(cancelStub.callCount, 0, 'callCancel should not be touched')
+  t.equal(call.status(), 'ended', 'status should be ended')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('call.end() on incoming ringing invokes puppet.callReject with reason', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  const CALL_ID = 'call-id-end-reject'
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'peer',
+    participants : [ 'peer', 'bot-self' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const rejectStub = sandbox.stub().resolves(undefined)
+  puppet.callReject = rejectStub
+
+  let incoming: CallInterface | undefined
+  ;(wechaty as any).on('call', (c: CallInterface) => { incoming = c })
+  ;(puppet as any).emit('call', {
+    callId    : CALL_ID,
+    signal    : PUPPET.types.CallSignal.Invite,
+    contactId : 'peer',
+    timestamp : 1,
+  } as PUPPET.payloads.EventCall)
+  await flush()
+  t.ok(incoming, 'prerequisite: incoming call should surface via bot.on(call)')
+  t.equal(incoming!.status(), 'ringing', 'prerequisite: incoming call should be ringing')
+
+  await incoming!.end('busy')
+  t.same(rejectStub.firstCall.args, [ CALL_ID, 'busy' ], 'callReject args should be [callId, reason]')
+  t.equal(incoming!.status(), 'ended', 'status should be ended')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('call.end() falls back to callHangup when callCancel is UNIMPLEMENTED', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  puppet.callInvite = sandbox.stub().resolves('call-id-end-fallback')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const cancelStub = sandbox.stub().rejects(new Error('12 UNIMPLEMENTED: CallCancel is not supported'))
+  const hangupStub = sandbox.stub().resolves(undefined)
+  puppet.callCancel = cancelStub
+  puppet.callHangup = hangupStub
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
+
+  await call.end('timeout')
+  t.equal(cancelStub.callCount, 1, 'callCancel should be attempted first')
+  t.same(hangupStub.firstCall.args, [ call.id, 'timeout' ], 'should retry via callHangup')
+  t.equal(call.status(), 'ended', 'status should be ended')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('call.end() retries via callHangup when peer accepts during in-flight cancel', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  puppet.callInvite = sandbox.stub().resolves('call-id-end-race')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const hangupStub = sandbox.stub().resolves(undefined)
+  puppet.callHangup = hangupStub
+  puppet.callCancel = sandbox.stub().callsFake(async (callId: string) => {
+    ;(puppet as any).emit('call', {
+      callId,
+      signal    : PUPPET.types.CallSignal.Accept,
+      contactId : 'peer',
+      timestamp : 2,
+    } as PUPPET.payloads.EventCall)
+    await flush()
+    throw new Error('call already answered')
+  })
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
+
+  await call.end('too late to cancel')
+  t.same(hangupStub.firstCall.args, [ call.id, 'too late to cancel' ], 'should retry via callHangup after accept race')
+  t.equal(call.status(), 'ended', 'status should be ended')
+
+  await wechaty.stop()
+  sandbox.restore()
+})
+
+test('call.end() rethrows non-recoverable pre-connect failures but still finalizes', async t => {
+  const { puppet, wechaty } = buildWechaty()
+  await startAndLogin(puppet, wechaty)
+
+  puppet.callInvite = sandbox.stub().resolves('call-id-end-fatal')
+  stubCallPayload(puppet, (id: string) => ({
+    id,
+    starter      : 'bot-self',
+    participants : [ 'bot-self', 'peer' ],
+    media        : PUPPET.types.CallMediaType.Audio,
+    startTime    : 1,
+  }))
+  const hangupStub = sandbox.stub().resolves(undefined)
+  puppet.callCancel = sandbox.stub().rejects(new Error('network error'))
+  puppet.callHangup = hangupStub
+
+  const contact = (wechaty.Contact as typeof ContactImpl).load('peer')
+  const call    = await contact.call()
+
+  await t.rejects(call.end(), /network error/, 'end() should re-throw transport failures')
+  t.equal(hangupStub.callCount, 0, 'no hangup retry for transport failures')
+  t.equal(call.status(), 'ended', 'status should still finalize')
+
+  await wechaty.stop()
+  sandbox.restore()
+})

--- a/src/user-modules/call.ts
+++ b/src/user-modules/call.ts
@@ -30,6 +30,18 @@ interface CallConstructorOptions {
 const CallMixinBase = wechatifyMixin(CallEventEmitter)
 
 /**
+ * Whether a puppet rejection means "this verb is not supported by the
+ * implementation" (gRPC UNIMPLEMENTED, or an explicit not-supported error),
+ * as opposed to a transport/business failure. Message-based on purpose:
+ * puppet errors cross the service boundary as GError and no structured
+ * status code survives the trip.
+ */
+function isVerbUnsupportedError (e: unknown): boolean {
+  const message = e instanceof Error ? e.message : String(e)
+  return /UNIMPLEMENTED|not\s+(?:supported|implemented)|unsupported/i.test(message)
+}
+
+/**
  * Call – a live, stateful call-control session abstraction.
  *
  * A Call is a first-class citizen alongside Message and Contact.
@@ -219,6 +231,65 @@ class CallMixin extends CallMixinBase {
     }
     try {
       await this.wechaty.puppet.callHangup(this.id, reason)
+    } finally {
+      this.__finalize()
+    }
+  }
+
+  /**
+   * Universal terminator (the "red button"): end the call from whatever
+   * state it is in, dispatching to the state-appropriate verb —
+   *
+   *   connected                     → puppet.callHangup(reason)
+   *   incoming + ringing            → puppet.callReject(reason)
+   *   outgoing + calling / ringing  → puppet.callCancel()
+   *   ended                         → no-op (idempotent)
+   *
+   * Unlike the precise verbs (cancel/reject/hangup), which throw on any state
+   * mismatch, end() absorbs the two failure modes inherent to check-then-act
+   * termination, retrying ONCE via callHangup when:
+   *
+   *   - the peer accepts while our pre-connect verb is in flight (the verb
+   *     comes back rejected but the session is now connected, so hangup is
+   *     the correct verb by the time we retry), or
+   *   - the puppet does not implement the chosen verb (protocols whose
+   *     transport folds cancel/reject into a single hangup action).
+   *
+   * Local state always finalizes, matching cancel/reject/hangup semantics:
+   * whichever side actually terminated the session, the protocol-side record
+   * is the arbiter and its verdict arrives via the terminal signal path.
+   */
+  async end (reason?: string): Promise<void> {
+    if (this.__status === 'ended') {
+      this.log.verbose('Call', 'end() no-op: already ended, callId=%s', this.id)
+      return
+    }
+
+    try {
+      if (this.__status === 'connected') {
+        await this.wechaty.puppet.callHangup(this.id, reason)
+        return
+      }
+
+      try {
+        if (this.__direction === 'incoming') {
+          await this.wechaty.puppet.callReject(this.id, reason)
+        } else {
+          await this.wechaty.puppet.callCancel(this.id)
+        }
+      } catch (e) {
+        const acceptedMeanwhile = this.status() === 'connected'
+        if (!acceptedMeanwhile && !isVerbUnsupportedError(e)) {
+          throw e
+        }
+        this.log.verbose(
+          'Call',
+          'end() pre-connect verb failed (%s), retrying via callHangup, callId=%s',
+          acceptedMeanwhile ? 'accepted meanwhile' : 'verb unsupported',
+          this.id,
+        )
+        await this.wechaty.puppet.callHangup(this.id, reason)
+      }
     } finally {
       this.__finalize()
     }


### PR DESCRIPTION
## Summary

- 新增 `Call.end(reason?)`：结束通话的统一入口（"红色按钮"），按当前状态分发到正确动词，调用方不再需要自带状态机知识
- 契约层不动：cancel/reject/hangup 三个精确动词与上行信号语义保持原样（SIP CANCEL/BYE 先例——协议留两个动词，话机只有一个红按钮）

## 分发表

| 状态 | 动词 |
|---|---|
| connected | `puppet.callHangup(reason)` |
| incoming + ringing | `puppet.callReject(reason)` |
| outgoing + calling / ringing | `puppet.callCancel()` |
| ended | 幂等 no-op |

## 竞态与降级（单次 callHangup 重试）

- **accept 竞态**：cancel/reject 在途时对端接通 → 所选动词被拒但会话已 connected，重试时 hangup 已是正确动词
- **动词未实现**：puppet 返回 UNIMPLEMENTED / not supported（如企微系底层把取消折叠进挂断同一条 CGI 的实现，见 juzibot/puppet-workzen#811）→ 降级 hangup
- 其它错误原样上抛；本地状态恒 finalize（与三个精确动词语义一致），终态归属由协议侧话单裁决

## Test plan

- [x] call.spec.ts 新增 6 用例：三路分发、幂等、UNIMPLEMENTED 降级、accept 竞态重试、不可恢复错误仍终结本地态
- [x] 本地全量 `npm run lint && npm test` 双绿（node 22）
- [ ] 下游试点：bot-nested 响铃超时路径可从 `call.cancel()` 迁移到 `call.end()`（对 workzen 类 puppet 免适配）