### PR TITLE
chore: 1.0.162 (release Call.end, #123)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty",
-  "version": "1.0.161",
+  "version": "1.0.162",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- bump 1.0.161 → 1.0.162，触发 NPM workflow 发布 #123 的 `Call.end()` 通用终结入口
- 无代码变更，仅版本号

合并后 NPM job 自动 publish；下游（bot-nested / demo）即可升级消费。