### PR TITLE
chore(deps): bump @juzi/wechaty-puppet to ^1.0.152

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.148",
+    "@juzi/wechaty-puppet": "^1.0.152",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.44",
     "@swc/helpers": "^0.3.6",


### PR DESCRIPTION
## What
Bumps the `@juzi/wechaty-puppet` **devDependency** `^1.0.148` → `^1.0.152`.

## Why
`@juzi/wechaty-puppet` 1.0.152 adds three optional fields to `PremiumOnlineAppointmentCardPayload` (`commentContent` / `authorNickname` / `authorAvatar`) for the Xiaohongshu share-note-comment & note cards. Aligning wechaty's dev/type dependency keeps the card type chain consistent.

## Compatibility
No code change. `PremiumOnlineAppointmentCard` holds `payload` by reference and `message-to-sayable` / `payload-to-sayable` pass it through, so the new optional fields flow through untouched. This is a `devDependency`, so published consumers are unaffected — they pin their own `@juzi/wechaty-puppet`.

Verified locally: `npm install` (resolves `@juzi/wechaty-puppet@1.0.152`) + `npm run build` (tsc ESM + CJS) pass.

> Package version bump left to the publish step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)